### PR TITLE
Adds eslint-config-google as distribution dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
   "author": "Liferay",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^3.17.1",
-    "eslint-config-google": "^0.7.1"
+    "eslint": "^3.17.1"
   },
   "peerDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^3.17.1"
+  },
+  "dependencies": {
     "eslint-config-google": "^0.7.1"
   }
 }


### PR DESCRIPTION
That's using ` eslint-config-google` as a peer, so that requires the user to install this package manually.

In the readme, it's not required: `npm install --save-dev eslint eslint-config-liferay`

Also, there's a comment explaining that it's not required: https://github.com/eduardolundgren/eslint-config-liferay/blob/master/index.js#L9


Currently, I'm getting this WARN and this dependency is not installed.

```
npm WARN eslint-config-liferay@1.0.0 requires a peer of eslint-config-google@^0.7.1 but none was installed.
```
If someone tries to perform eslint, it throws an error:

```
Error: Cannot find module 'eslint-config-google'
```
