### PR TITLE
Add missing license headers to files (#17)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 module.exports = {
 	env: {
 		browser: true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Chema Balsas
+Copyright (c) 2017 Liferay, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/copyright.js
+++ b/copyright.js
@@ -1,0 +1,6 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 'use strict';
 
-module.exports = {
+const fs = require('fs');
+
+const config = {
 	env: {
 		es6: true,
 	},
@@ -9,7 +17,7 @@ module.exports = {
 		ecmaVersion: 2017,
 		sourceType: 'module',
 	},
-	plugins: ['liferayportal', 'no-only-tests'],
+	plugins: ['liferayportal', 'no-only-tests', 'notice'],
 	rules: {
 		'liferayportal/arrowfunction-newline': 0,
 		'no-console': 0,
@@ -37,3 +45,14 @@ module.exports = {
 		'arrow-parens': 0, // Setting for Prettier
 	},
 };
+
+if (fs.existsSync('copyright.js')) {
+	config.rules['notice/notice'] = [
+		'error',
+		{
+			templateFile: 'copyright.js',
+		},
+	];
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 	"dependencies": {
 		"eslint-config-prettier": "4.1.0",
 		"eslint-plugin-liferayportal": "^1.0.0",
-		"eslint-plugin-no-only-tests": "^2.1.0"
+		"eslint-plugin-no-only-tests": "^2.1.0",
+		"eslint-plugin-notice": "0.7.8"
 	},
 	"scripts": {
 		"format": "prettier --write -- '**/*.{js,json,md}' '.*.js'",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,3 +1,9 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,6 +192,15 @@ eslint-plugin-no-only-tests@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.1.0.tgz#9050450bace6abbc457de894116141936fec68e7"
   integrity sha512-T02dNNDj7sKJNvH7YLKqgv4+BDupxKG4OgadF0AecDHrYTb9hlosxqCgZbFKt28C7Ueof6ziCtEh6rnPvN4YYA==
 
+eslint-plugin-notice@0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-notice/-/eslint-plugin-notice-0.7.8.tgz#c6887927061fcf1c638c0559476045a521703006"
+  integrity sha512-a18VwxiBp4TmXRVpx7T5D4ilHnMS1Gq/5OMUriCcJGHD72Cbji7qVk19DGOW9vBHnJJKeg0yU95a7/o8JQoMCw==
+  dependencies:
+    find-root "^1.1.0"
+    lodash ">=2.4.0"
+    metric-lcs "^0.1.2"
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -327,6 +336,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -482,10 +496,15 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.17.11:
+lodash@>=2.4.0, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+metric-lcs@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/metric-lcs/-/metric-lcs-0.1.2.tgz#87913f149410e39c7c5a19037512814eaf155e11"
+  integrity sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
- Teach eslint-config-liferay to use the contents of "copyright.js" as a license header, if present in the project root. This will enable this to work automatically with the Clay repo, for example, which [already has such a header file](https://github.com/liferay/clay/blob/01432f23daa1a3abac3380b17b0545779bdefb1e/copyright.js) on the "develop" branch.
- Use `yarn lint:fix` to apply header to existing files.
- Update copyright assignment from @jbalsas to Liferay, Inc; obviously will want Chema to sign off on this.

Closes: https://github.com/liferay/eslint-config-liferay/issues/17