### PR TITLE
Fix pre-existing lints inside eslint-config-liferay

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/.eslintrc-internal.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,9 @@
 
 module.exports = {
 	env: {
-		browser: true,
-		jest: true,
-		mocha: true,
+		// Available environments: https://eslint.org/docs/user-guide/configuring#specifying-environments
+		es6: true,
+		node: true,
 	},
 	extends: 'liferay',
 	globals: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,25 +23,5 @@ module.exports = {
 		themeDisplay: true,
 		tinyMCE: true,
 	},
-	rules: {
-		'lines-around-comment': [
-			'error',
-			{
-				afterBlockComment: false,
-				afterLineComment: true,
-				beforeBlockComment: false,
-				beforeLineComment: false,
-			},
-		],
-		'padding-line-between-statements': [
-			'error',
-			{blankLine: 'always', prev: '*', next: 'return'},
-			{blankLine: 'always', prev: ['const', 'let', 'var'], next: '*'},
-			{
-				blankLine: 'any',
-				prev: ['const', 'let', 'var'],
-				next: ['const', 'let', 'var'],
-			},
-		],
-	},
+	rules: {},
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,5 @@
+# Generated file.
 /.eslintrc-internal.js
+
+# We don't want Prettier to strip the trailing blank line.
+/copyright.js


### PR DESCRIPTION
The "env" section of the default ".eslintrc.js" file is one of the places that we expect pretty much every consuming project to have to customize, so do two things:

1. Update it to fix the existing lints in eslint-config-liferay itself.
2. Provide a link so that people can easily look-up the allowed set of "env" settings for their projects.

Closes: https://github.com/liferay/eslint-config-liferay/issues/27