### PR TITLE
 Sync with latest changes from liferay/clay (#25)

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,23 +26,6 @@ const config = {
 		'no-only-tests/no-only-tests': 'error',
 		'no-unused-expressions': 'error',
 		'no-process-env': 'off',
-		'comma-spacing': 'off',
-		indent: ['error', 'tab'],
-		'keyword-spacing': 'warn',
-		'max-len': [
-			'error',
-			{
-				code: 80,
-				comments: 120,
-				ignoreRegExpLiterals: true,
-				ignoreStrings: true,
-				ignoreTemplateLiterals: true,
-				ignoreUrls: true,
-				tabWidth: 4,
-			},
-		],
-		'no-tabs': 'off',
-		'arrow-parens': 'off', // Setting for Prettier
 	},
 };
 

--- a/index.js
+++ b/index.js
@@ -20,12 +20,8 @@ const config = {
 	plugins: ['liferayportal', 'no-only-tests', 'notice'],
 	rules: {
 		'liferayportal/arrowfunction-newline': 'off',
-		'no-console': 'off',
-		'no-constant-condition': 'off',
-		'no-empty': 'off',
 		'no-only-tests/no-only-tests': 'error',
 		'no-unused-expressions': 'error',
-		'no-process-env': 'off',
 	},
 };
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,27 @@ const config = {
 		ecmaVersion: 2017,
 		sourceType: 'module',
 	},
-	plugins: ['liferayportal', 'no-only-tests', 'notice'],
+	plugins: [
+		'liferayportal',
+		'no-for-of-loops',
+		'no-only-tests',
+		'notice',
+		'sort-destructure-keys',
+	],
 	rules: {
+		'default-case': 'error',
 		'liferayportal/arrowfunction-newline': 'off',
+		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-only-tests/no-only-tests': 'error',
+		'no-return-assign': ['error', 'always'],
 		'no-unused-expressions': 'error',
+		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
+		'object-shorthand': 'error',
+		'prefer-const': 'error',
+		'quote-props': ['error', 'as-needed'],
+		'sort-destructure-keys/sort-destructure-keys': 'error',
+		'sort-keys': 'error',
+		'sort-vars': 'error',
 	},
 };
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
 	"dependencies": {
 		"eslint-config-prettier": "4.1.0",
 		"eslint-plugin-liferayportal": "^1.0.0",
+		"eslint-plugin-no-for-of-loops": "^1.0.0",
 		"eslint-plugin-no-only-tests": "^2.1.0",
-		"eslint-plugin-notice": "0.7.8"
+		"eslint-plugin-notice": "0.7.8",
+		"eslint-plugin-sort-destructure-keys": "^1.2.0"
 	},
 	"scripts": {
 		"format": "prettier --write -- '**/*.{js,json,md}' '.*.js'",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -32,12 +32,16 @@ function detectPackageJSONConfig() {
 	}
 }
 
+function log(message) {
+	console.log(message); // eslint-disable-line no-console
+}
+
 const config = eslintrcFilenames.find(findConfig);
 
 if (config) {
-	console.log(`Preserving .eslintrc file found at ${config}`);
+	log(`Preserving .eslintrc file found at ${config}`);
 } else if (detectPackageJSONConfig()) {
-	console.log('Existing "eslintConfig" property found in package.json');
+	log('Existing "eslintConfig" property found in package.json');
 } else {
 	fs.writeFileSync(
 		config,
@@ -46,5 +50,5 @@ if (config) {
 		})
 	);
 
-	console.log(`Created ${config}`);
+	log(`Created ${config}`);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,11 @@ eslint-plugin-liferayportal@^1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
+eslint-plugin-no-for-of-loops@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-for-of-loops/-/eslint-plugin-no-for-of-loops-1.0.0.tgz#a13d91a8f1922f7fefedeab351dc0055994601f6"
+  integrity sha1-oT2RqPGSL3/v7eqzUdwAVZlGAfY=
+
 eslint-plugin-no-only-tests@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.1.0.tgz#9050450bace6abbc457de894116141936fec68e7"
@@ -200,6 +205,13 @@ eslint-plugin-notice@0.7.8:
     find-root "^1.1.0"
     lodash ">=2.4.0"
     metric-lcs "^0.1.2"
+
+eslint-plugin-sort-destructure-keys@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.2.0.tgz#1dddbc775bd3672319fd92f88d4efd6fe88dba1b"
+  integrity sha512-2rvRzhImWcq9r0hBojlvzCKlT7lYLrHCH/N37GWu7SKdn3G0PbEIXLt5pdHY6I4F49bmBQr1+7cBMM8XWv0xgQ==
+  dependencies:
+    natural-compare-lite "^1.4.0"
 
 eslint-scope@^4.0.0:
   version "4.0.0"
@@ -539,6 +551,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Sync with latest changes from liferay/clay (#25)

Based on looking at the current "develop" plugins and rules:

https://github.com/liferay/clay/blob/01432f23daa1a3abac3380b17b0545779bdefb1e/.eslintrc

Comments added inline:

```javascript
"plugins": [
        // Already included:
        "notice",

        // The intent of this one is to avoid needing
        // a Symbol.iterator polyfill for older browsers.
        // This one is probably a bit too opinionated to
        // go in the default, but we are using it in multiple
        // places and IE doesn't have Symbol.iterator...
        "no-for-of-loops",

        // Probably don't want to include this in the default
        // because not all of our projects use React.
        "react"
],
"rules": {
        // See above.
        "no-for-of-loops/no-for-of-loops": 2,

        // On by default in eslint:recommended but we override the
        // default options.
        // "ignoreRestSiblings" strikes me as unnecessarily lax.
        // I'd rather see us use options like: `{argsIgnorePattern: '^_'}`.
        "no-unused-vars": ["error", {"ignoreRestSiblings": true}],

        // See above.
        "react/jsx-uses-react": "error",
        "react/jsx-uses-vars": "error",

        // Shouldn't be needed as Prettier should handle this.
        "no-mixed-spaces-and-tabs": ["error", "smart-tabs"],

        // See above.
        "notice/notice": [
                "error",
                {
                        "templateFile": "copyright.js"
                }
        ]
}
```

And in the PR:

https://github.com/liferay/clay/pull/1548/files#diff-df39304d828831c44a2b9f38cd45289c

```javascript
"plugins": [
        // As above.
        "notice",
        "no-for-of-loops",
        "react",

        // Another React-related one that probably doesn't
        // belong in the base.
        "react-hooks",

        // This one seems fair enough.
        "sort-destructure-keys",

        // This one is a bit scary/invasive, and we haven't
        // used it outside of a PR yet, but we can try it;
        // if it works well then we should bake it in to
        // the default.
        "sort-imports-es6-autofix"
],
"rules": {
        // Should be handled by Prettier.
        "comma-dangle": [2, "always"],

        // This is a good one, and not in the default eslint:recommended.
        "default-case": 2,

        // Prettier.
        "eol-last": [2, "never"],

        // Prettier, and not on by default anyway.
        "max-len": 0,

        // Already in eslint:recommended.
        "no-console": 2,

        // See above.
        "no-for-of-loops/no-for-of-loops": 2,

        // Prettier.
        "no-mixed-spaces-and-tabs": ["error", "smart-tabs"],

        // This is a good one, and not in the default eslint:recommended.
        "no-return-assign": [2, "always"],

        // Already in eslint:recommended.
        "no-undef": 2,

        // This one is dubious, and not in default eslint:recommended.
        // (Dubious because allowing underscores after this but prohibiting
        // them in method names seems a bit arbitrary or contradictory).
        // I wouldn't put this one in the default.
        "no-underscore-dangle": [
                2,
                {
                        "allowAfterThis": true,
                        "enforceInMethodNames": true
                }
        ],

        // Note this contradicts the setting on "develop"
        // (which uses `ignoreRestSiblings: true`). I'd
        // recommend the dumb/simple config that I suggested
        // above instead.
        "no-unused-vars": [
                2,
                {
                        "args": "after-used",
                        "ignoreRestSiblings": false,
                        "vars": "all"
                }
        ],

        // See above.
        "notice/notice": [
                "error",
                {
                        "template": "..."
                }
        ],

        // Seems reasonable and not in eslint:recommended.
        "object-shorthand": 2,

        // A splendid rule, and not in eslint:recommended.
        "prefer-const": 2,

        // In general I like this rule, but I think it might be a bit
        // too opinionated to go in the default set.
        "prefer-template": 2,

        // A reasonable addition and not in eslint:recommended.
        "quote-props": [2, "as-needed"],

        // Not sure whether this one conflicts/duplicates relative to
        // Prettier, but the options (single, avoid-escape) seem right.
        "quotes": [2, "single", "avoid-escape"],

        // All React, so ignoring for the purposes of the default config.
        "react-hooks/rules-of-hooks": "error",
        "react/jsx-boolean-value": 2,
        "react/jsx-handler-names": 2,
        "react/jsx-key": 2,
        "react/jsx-no-bind": 2,
        "react/jsx-no-literals": 2,
        "react/jsx-sort-props": 2,
        "react/jsx-uses-react": "error",
        "react/jsx-uses-vars": 2,

        // Surprised to see this one off in Clay. I'm happy to keep
        // this out of the preset, pending agreement from others:
        // moving to TypeScript would mean less heavy reliance on JSDoc,
        // freeing it to be used to highlight actually important things
        // as opposed to redundantly encoding them.
        "require-jsdoc": 0,

        // Discussed above.
        "sort-destructure-keys/sort-destructure-keys": 2,
        "sort-imports-es6-autofix/sort-imports-es6": [
                2,
                {
                        "ignoreCase": true,
                        "ignoreMemberSort": false,
                        "memberSyntaxSortOrder": ["none", "all", "single", "multiple"]
                }
        ],

        // This rule is good, although not in eslint:recommended,
        // but I think we should accept the default (`caseSensitive: true`)
        // rather than overriding it.
        "sort-keys": [
                2,
                "asc",
                {
                        "caseSensitive": false
                }
        ],

        // Another reasonable rule, not in eslint:recommended
        "sort-vars": 2
}
```

Closes: https://github.com/liferay/eslint-config-liferay/issues/25