### PR TITLE
Tweak rules and plug-ins based on experience integrating into other projects (#33)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,7 @@ const config = {
 		ecmaVersion: 2017,
 		sourceType: 'module',
 	},
-	plugins: [
-		'liferayportal',
-		'no-for-of-loops',
-		'no-only-tests',
-		'notice',
-		'sort-destructure-keys',
-	],
+	plugins: ['liferayportal', 'no-for-of-loops', 'no-only-tests', 'notice'],
 	rules: {
 		'default-case': 'error',
 		'liferayportal/arrowfunction-newline': 'off',
@@ -35,9 +29,6 @@ const config = {
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
 		'quote-props': ['error', 'as-needed'],
-		'sort-destructure-keys/sort-destructure-keys': 'error',
-		'sort-keys': 'error',
-		'sort-vars': 'error',
 	},
 };
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
 		"eslint-plugin-liferayportal": "^1.0.0",
 		"eslint-plugin-no-for-of-loops": "^1.0.0",
 		"eslint-plugin-no-only-tests": "^2.1.0",
-		"eslint-plugin-notice": "0.7.8",
-		"eslint-plugin-sort-destructure-keys": "^1.2.0"
+		"eslint-plugin-notice": "0.7.8"
 	},
 	"scripts": {
 		"format": "prettier --write -- '**/*.{js,json,md}' '.*.js'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,13 +206,6 @@ eslint-plugin-notice@0.7.8:
     lodash ">=2.4.0"
     metric-lcs "^0.1.2"
 
-eslint-plugin-sort-destructure-keys@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.2.0.tgz#1dddbc775bd3672319fd92f88d4efd6fe88dba1b"
-  integrity sha512-2rvRzhImWcq9r0hBojlvzCKlT7lYLrHCH/N37GWu7SKdn3G0PbEIXLt5pdHY6I4F49bmBQr1+7cBMM8XWv0xgQ==
-  dependencies:
-    natural-compare-lite "^1.4.0"
-
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -551,11 +544,6 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
As part of https://github.com/liferay/eslint-config-liferay/issues/21 I made PRs to update a few projects:

- alloy-editor: https://github.com/liferay/alloy-editor/pull/1168
  - Turned off "sort-keys" because it was super noisy.
- liferay-npm-build-tools: https://github.com/liferay/liferay-npm-build-tools/pull/278
  - Turned off "sort-keys" because it would require huge changes.
  - Found "sort-destructure-keys/sort-destructure-keys" to be pretty annoying.
- liferay-amd-loader: https://github.com/liferay/liferay-amd-loader/pull/190
  - Surprise, surprise, turned off "sort-keys" again

So I think on the basis of those PRs, we should probably turn off at "sort-keys" and "sort-destructure-keys", and let's kill "sort-vars" too, which was one of the main remaining generators of churn in those PRs.

Closes: https://github.com/liferay/eslint-config-liferay/issues/33