### PR TITLE
Change quote-props rule to "consistent-as-needed"

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,6 +2,7 @@
 	"trailingComma": "es5",
 	"bracketSpacing": false,
 	"jsxBracketSameLine": true,
+	"quoteProps": "consistent",
 	"singleQuote": true,
 	"tabWidth": 4,
 	"useTabs": true

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const config = {
 		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
-		'quote-props': ['error', 'as-needed'],
+		'quote-props': ['error', 'consistent-as-needed'],
 	},
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,9 +193,9 @@ eslint-plugin-no-for-of-loops@^1.0.0:
   integrity sha1-oT2RqPGSL3/v7eqzUdwAVZlGAfY=
 
 eslint-plugin-no-only-tests@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.1.0.tgz#9050450bace6abbc457de894116141936fec68e7"
-  integrity sha512-T02dNNDj7sKJNvH7YLKqgv4+BDupxKG4OgadF0AecDHrYTb9hlosxqCgZbFKt28C7Ueof6ziCtEh6rnPvN4YYA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.3.0.tgz#1b0007c3b2600c74ad5f144d24bfef620e824c9d"
+  integrity sha512-5YZvazTJLWrGU8WUq3xp0Eot02zK/yUT9GoVjrFdXP8flVqH6YBdC6PsAKBRIpcs48WvSfSYrmdwAj3a4d/Iyg==
 
 eslint-plugin-notice@0.7.8:
   version "0.7.8"
@@ -614,9 +614,9 @@ prelude-ls@~1.1.2:
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 prettier@*:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
I just got bitten by this while preparing [this PR](https://github.com/liferay/liferay-js-themes-toolkit/pull/247).

Basically, given an object containing some version numbers properties:

```
{
  '6.2': true,
  '7.0': true,
  '7.1': true,
}
```

we currently have ESLint configured via "quote-props" to require quotes around property names "as-needed"; producing this:

```
{
  6.2: true,
  '7.0': true,
  7.1: true,
}
```

This looks pretty terrible. I noticed that Prettier didn't have an opinion on this, so I changed them all to skip the quotes:

```
{
  6.2: true,
  7.0: true,
  7.1: true,
}
```

of course, that is wrong too, because `7.0` actually gets stringified to `'7'`, meaning the object is equivalent to:

```
{
  '6.2': true,
  '7': true,
  '7.1': true,
}
```

This breaks checks of the form `if (object['7.0'] === true)`. So I added a lint suppression and put strings back on all the keys, but we should just configure ESLint to use "consistent-as-needed" instead. [The docs](https://eslint.org/docs/rules/quote-props)) describe it like so:

> requires quotes around all object literal property names if any name
> strictly requires quotes, otherwise disallows quotes around object
> property names

Test plan: tweak my local copy of eslint-config-liferay in the repo with the PR I linked at the top and confirm that all-quotes are enforced in that object but not in other places. It's not a total bed of roses, unfortunately. I found that if you start with an object like this:

```
{
  a: 1,
  'b-c': 2,
}
```

it will get changed to:

```
{
  "a": 1,
  'b-c': 2,
}
```

on the bright side, if you then change it to use single quotes, it stays that way. Closest ticket I can find for an issue like this is:

https://github.com/Microsoft/vscode-eslint/issues/209

So, it's a wrinkle, but I still think we're better off with this change than without it.

Closes: https://github.com/liferay/eslint-config-liferay/issues/38