### PR TITLE
chore: remove liferayportal plugin (#40)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,9 @@ const config = {
 		ecmaVersion: 2017,
 		sourceType: 'module',
 	},
-	plugins: ['liferayportal', 'no-for-of-loops', 'no-only-tests', 'notice'],
+	plugins: ['no-for-of-loops', 'no-only-tests', 'notice'],
 	rules: {
 		'default-case': 'error',
-		'liferayportal/arrowfunction-newline': 'off',
 		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-only-tests/no-only-tests': 'error',
 		'no-return-assign': ['error', 'always'],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 	},
 	"dependencies": {
 		"eslint-config-prettier": "4.1.0",
-		"eslint-plugin-liferayportal": "^1.0.0",
 		"eslint-plugin-no-for-of-loops": "^1.0.0",
 		"eslint-plugin-no-only-tests": "^2.1.0",
 		"eslint-plugin-notice": "0.7.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,13 +180,6 @@ eslint-config-prettier@4.1.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-liferayportal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-liferayportal/-/eslint-plugin-liferayportal-1.0.1.tgz#2891b423413db3518a507eda56c664af218635c7"
-  integrity sha512-YOqhDwqtj/K4BSH6ToMMTONHX7VASQoVv2iwPIsetD0aV5DywdTpdj0ZOA8eY9jmhfl+aFbbUjy6jD0YqE2suw==
-  dependencies:
-    requireindex "~1.1.0"
-
 eslint-plugin-no-for-of-loops@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-for-of-loops/-/eslint-plugin-no-for-of-loops-1.0.0.tgz#a13d91a8f1922f7fefedeab351dc0055994601f6"
@@ -632,11 +625,6 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
The plugin had a custom rule to deal with arrow functions but all of this is (or should be) handled by Prettier now.

Closes: https://github.com/liferay/eslint-config-liferay/issues/40