### PR TITLE
feat: add liferay/no-it-should rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ For React projects, you can extend `liferay/react` instead:
 
 The included [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugin-notice) plug-in can be used to enforce the use of uniform copyright headers across a project by placing a template named `copyright.js` in the project root (for example, see [the file defining the headers used in eslint-config-liferay itself](https://github.com/liferay/eslint-config-liferay/blob/master/copyright.js)).
 
+### Custom rules
+
+#### `eslint-plugin-liferay`
+
+The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plugins/eslint-plugin-liferay/docs/rules):
+
+-   [liferay/no-it-should](./plugins/eslint-plugin-liferay/docs/rules/no-it-should.md): This rule enforces that `it()` descriptions start with a verb, not with "should".
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const fs = require('fs');
+const local = require('./utils/local');
 
 const config = {
 	env: {
@@ -17,9 +18,10 @@ const config = {
 		ecmaVersion: 2017,
 		sourceType: 'module',
 	},
-	plugins: ['no-for-of-loops', 'no-only-tests', 'notice'],
+	plugins: [local('liferay'), 'no-for-of-loops', 'no-only-tests', 'notice'],
 	rules: {
 		'default-case': 'error',
+		'liferay/no-it-should': 'error',
 		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-only-tests/no-only-tests': 'error',
 		'no-return-assign': ['error', 'always'],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
 	"files": [
 		".eslintrc.js",
 		"index.js",
+		"plugins",
 		"react.js",
-		"scripts"
+		"scripts",
+		"utils"
 	],
 	"keywords": [
 		"code",
@@ -38,11 +40,12 @@
 		"eslint-plugin-react-hooks": "1.6.0"
 	},
 	"scripts": {
-		"ci": "yarn lint && yarn format:check",
+		"ci": "yarn lint && yarn format:check && yarn test",
 		"format": "prettier --write -- '**/*.{js,json,md}' '.*.js'",
 		"format:check": "prettier --list-different -- '**/*.{js,json,md}' '.*.js'",
 		"lint": "node scripts/lint.js",
 		"lint:fix": "node scripts/lint.js --fix",
-		"postinstall": "node scripts/postinstall.js"
+		"postinstall": "node scripts/postinstall.js",
+		"test": "node scripts/test.js"
 	}
 }

--- a/plugins/eslint-plugin-liferay/docs/rules/no-it-should.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-it-should.md
@@ -1,0 +1,27 @@
+# `it()` strings should not start with "should" (no-it-should)
+
+This rule enforces that `it()` descriptions start with a verb, not with "should".
+
+## Rule Details
+
+Descriptions that start with "should" can usually be rewritten more concisely and without loss of information by dropping the "should" and starting with an appropriate verb. This is useful because it reduces the likelihood we'll have to introduce an ugly linebreak that harms readability.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('should reload after clicking', () => {
+	// ...
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('reloads after clicking', () => {
+	// ...
+});
+```
+
+## Further Reading
+
+-   [Liferay Frontend Guidelines for testing](https://github.com/liferay/liferay-frontend-guidelines/blob/master/guidelines/general/testing.md)

--- a/plugins/eslint-plugin-liferay/index.js
+++ b/plugins/eslint-plugin-liferay/index.js
@@ -1,0 +1,11 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+module.exports = {
+	rules: {
+		'no-it-should': require('./lib/rules/no-it-should'),
+	},
+};

--- a/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
@@ -1,0 +1,46 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const DESCRIPTION = 'it() strings should not start with "should"';
+
+module.exports = {
+	meta: {
+		docs: {
+			description: DESCRIPTION,
+			category: 'Test style',
+			recommended: false,
+			url:
+				'https://github.com/liferay/liferay-frontend-guidelines/blob/master/guidelines/general/testing.md#start-it-descriptions-with-a-verb-not-with-should',
+		},
+		fixable: null, // or "code" or "whitespace"
+		schema: [],
+		type: 'suggestion',
+	},
+
+	create(context) {
+		return {
+			CallExpression(node) {
+				if (
+					node.callee.type === 'Identifier' &&
+					node.callee.name === 'it'
+				) {
+					const argument = node.arguments && node.arguments[0];
+					if (
+						argument &&
+						argument.type === 'Literal' &&
+						typeof argument.value === 'string' &&
+						argument.value.match(/\s*should/)
+					) {
+						context.report({
+							message: DESCRIPTION,
+							node: argument,
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/plugins/eslint-plugin-liferay/package.json
+++ b/plugins/eslint-plugin-liferay/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "eslint-plugin-liferay",
+	"version": "1.0.0",
+	"main": "index.js",
+	"directories": {
+		"doc": "docs",
+		"lib": "lib",
+		"test": "tests"
+	},
+	"private": true
+}

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
@@ -1,0 +1,30 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/no-it-should');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-it-should', rule, {
+	valid: [
+		{
+			code: 'it("behaves")',
+		},
+	],
+
+	invalid: [
+		{
+			code: "it('should do the right thing')",
+			errors: [
+				{
+					message: 'it() strings should not start with "should"',
+					type: 'Literal',
+				},
+			],
+		},
+	],
+});

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,33 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const plugins = path.join(__dirname, '../plugins');
+
+let status = 0;
+
+fs.readdirSync(plugins).forEach(plugin => {
+	const rules = path.join(plugins, plugin, 'tests/lib/rules');
+
+	fs.readdirSync(rules).forEach(rule => {
+		const file = path.join(rules, rule);
+
+		try {
+			require(file);
+		} catch (error) {
+			status = 1;
+
+			const location = path.relative('', file);
+
+			// eslint-disable-next-line no-console
+			console.log(`In ${location}:\n\n${error}`);
+		}
+	});
+});
+
+process.exit(status);

--- a/utils/local.js
+++ b/utils/local.js
@@ -1,0 +1,63 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * ESLint doesn't provide a way to bundle a config and rules together in one
+ * package, so this ghastly helper monkey-patches `require` to enable us to
+ * expose bundled rule plugins from inside eslint-config-liferay without
+ * actually having to separately publish a "eslint-plugin-liferay" or
+ * "eslint-plugin-liferay-portal" package.
+ */
+
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+
+const localPlugins = new Map();
+
+let originalRequire;
+
+/**
+ * Monkey-patches `require` with an override that knows how to locate plug-ins
+ * that have been previously registered with `local()`.
+ */
+function patch() {
+	if (!originalRequire) {
+		originalRequire = Module.prototype.require;
+
+		Module.prototype.require = function(id) {
+			if (localPlugins.has(id)) {
+				return originalRequire.call(this, localPlugins.get(id));
+			} else {
+				return originalRequire.call(this, id);
+			}
+		};
+	}
+}
+
+/**
+ * Registers `pluginName` as a local plugin bundled with eslint-config-liferay.
+ */
+function local(pluginName) {
+	const basename = pluginName.startsWith('eslint-plugin-')
+		? pluginName
+		: `eslint-plugin-${pluginName}`;
+
+	const location = path.join(__dirname, '../plugins/', basename);
+
+	if (!fs.existsSync(location)) {
+		throw new Error(`local(): no plug-in found at ${location}`);
+	}
+
+	localPlugins.set(basename, location);
+
+	// Make sure `require()` implementation is patched.
+	patch();
+
+	return pluginName;
+}
+
+module.exports = local;


### PR DESCRIPTION
Implements enforcement of:

https://github.com/liferay/liferay-frontend-guidelines/blob/master/guidelines/general/testing.md

As noted in the comments, ESLint surprisingly doesn't make it easy for you to bundle rules with a config, requiring you to publish a separate package. That is, if you have "eslint-config-foo", you have to stick your rules in "eslint-plugin-foo". The inverse doesn't appear to be true: if you have "eslint-plugin-foo", you can bundle configs with it without having to create "eslint-config-foo".

We however, have "eslint-config-liferay", and I don't want to create yet another package, so we use a horrifying but well-contained hack that is hidden away in `utils/local.js` to enable us to bundle local rules with our config. No need to look in there, really.

So, we now have a "plugins" subdirectory where we keep our local rules, starting with this "liferay/no-it-should" rule, which we should be able to use in all of our projects, and which you can see in "plugins/eslint-plugin-liferay". The actual structure of this is determined by the "generator-eslint" Yeoman generator, which is why it doesn't exactly follow our own conventions (eg. it has a "tests" directory in instead of a "test" directory). Likewise, things like having a "docs" folder are just expected for all ESLint rules. I included a link from the top-level README for visibility.