### PR TITLE
feat: add liferay/no-side-navigation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Once the `eslint-config-liferay` package is installed, you can use it by specify
 }
 ```
 
+### liferay-portal
+
+In [liferay-portal](https://github.com/liferay/liferay-portal) itself we extend the `liferay/portal` preset instead, which activates some additional rules specific to liferay-portal. See the `eslint-plugin-liferay-portal` section below for more details.
+
 ### React
 
 For React projects, you can extend `liferay/react` instead:
@@ -28,6 +32,17 @@ For React projects, you can extend `liferay/react` instead:
 ```js
 {
   "extends": ["liferay/react"],
+  "rules": {
+    // Additional, per-project rules...
+  }
+}
+```
+
+Or, for React projects inside liferay-portal, extend both `liferay/react` and `liferay/portal`:
+
+```js
+{
+  "extends": ["liferay/react", "liferay/portal"],
   "rules": {
     // Additional, per-project rules...
   }
@@ -44,7 +59,13 @@ The included [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugi
 
 The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plugins/eslint-plugin-liferay/docs/rules):
 
--   [liferay/no-it-should](./plugins/eslint-plugin-liferay/docs/rules/no-it-should.md): This rule enforces that `it()` descriptions start with a verb, not with "should".
+-   [liferay/no-it-should](./plugins/eslint-plugin-liferay/docs/rules/no-it-should.md): Enforces that `it()` descriptions start with a verb, not with "should".
+
+#### `eslint-plugin-liferay-portal`
+
+The bundled `eslint-plugin-liferay-portal` plugin includes the following [rules](./plugins/eslint-plugin-liferay-portal/docs/rules):
+
+-   [liferay/no-side-navigation](./plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		".eslintrc.js",
 		"index.js",
 		"plugins",
+		"portal.js",
 		"react.js",
 		"scripts",
 		"utils"

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md
@@ -1,0 +1,30 @@
+# Disallow use of deprecated jQuery `sideNavigation` plugin (no-side-navigation)
+
+This rule guards against the use of the deprecated jQuery `sideNavigation()` API, which was ported to vanilla JavaScript in [LPS-95476](https://github.com/brianchandotcom/liferay-portal/pull/74090).
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+$(toggler).sideNavigation();
+
+$(toggler).sideNavigation('hide');
+
+<span data-toggle="sidenav"></span>;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+Liferay.SideNavigation.initialize(toggler);
+
+Liferay.SideNavigation.hide(toggler);
+
+<span data-toggle="liferay-sidenav"></span>;
+```
+
+## Further Reading
+
+-   [LPS-95476 Port side-navigation.js jQuery plugin from Clay to vanilla JS](https://github.com/brianchandotcom/liferay-portal/pull/74090)
+-   [LPS-96486 Add lint to enforce use of new SideNavigation API](https://issues.liferay.com/browse/LPS-96486)

--- a/plugins/eslint-plugin-liferay-portal/index.js
+++ b/plugins/eslint-plugin-liferay-portal/index.js
@@ -1,0 +1,11 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+module.exports = {
+	rules: {
+		'no-side-navigation': require('./lib/rules/no-side-navigation'),
+	},
+};

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-side-navigation.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-side-navigation.js
@@ -1,0 +1,61 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+module.exports = {
+	meta: {
+		docs: {
+			description:
+				'jQuery `sideNavigation` plugin is deprecated; use Liferay.SideNavigation instead',
+			category: 'Deprecated APIs',
+			recommended: false,
+			url: 'https://issues.liferay.com/browse/LPS-96486',
+		},
+		fixable: null,
+		messages: {
+			noDataToggleSidenav:
+				'data-toggle="sidenav" is deprecated; use data-toggle="liferay-sidenav" instead',
+			noSideNavigation:
+				'sideNavigation() is deprecated; use Liferay.SideNavigation() instead',
+		},
+		schema: [],
+		type: 'problem',
+	},
+
+	create(context) {
+		return {
+			JSXAttribute(node) {
+				if (
+					node.type === 'JSXAttribute' &&
+					node.name.type === 'JSXIdentifier' &&
+					node.name.name === 'data-toggle' &&
+					node.value &&
+					node.value.type === 'Literal' &&
+					typeof node.value.value === 'string' &&
+					node.value.value.match(/^\s*sidenav\s*$/)
+				) {
+					context.report({
+						messageId: 'noDataToggleSidenav',
+						node,
+					});
+				}
+			},
+
+			CallExpression(node) {
+				if (
+					node.callee.type === 'MemberExpression' &&
+					node.callee.property &&
+					node.callee.property.type === 'Identifier' &&
+					node.callee.property.name === 'sideNavigation'
+				) {
+					context.report({
+						messageId: 'noSideNavigation',
+						node,
+					});
+				}
+			},
+		};
+	},
+};

--- a/plugins/eslint-plugin-liferay-portal/package.json
+++ b/plugins/eslint-plugin-liferay-portal/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "eslint-plugin-liferay-portal",
+	"version": "1.0.0",
+	"main": "index.js",
+	"directories": {
+		"doc": "docs",
+		"lib": "lib",
+		"test": "tests"
+	},
+	"private": true
+}

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
@@ -1,0 +1,69 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/no-side-navigation');
+
+const parserOptions = {
+	ecmaFeatures: {
+		jsx: true,
+	},
+};
+
+const ruleTester = new RuleTester({parserOptions});
+
+ruleTester.run('no-side-navigation', rule, {
+	valid: [
+		{
+			code: 'Liferay.SideNavigation.intialize(toggler)',
+		},
+		{
+			code: 'Liferay.SideNavigation.hide(toggler)',
+		},
+		{
+			code: '<span data-toggle="liferay-sidenav"></span>',
+		},
+	],
+
+	invalid: [
+		{
+			code: '$(toggler).sideNavigation()',
+			errors: [
+				{
+					messageId: 'noSideNavigation',
+					type: 'CallExpression',
+				},
+			],
+		},
+		{
+			code: "$(toggler).sideNavigation('hide')",
+			errors: [
+				{
+					messageId: 'noSideNavigation',
+					type: 'CallExpression',
+				},
+			],
+		},
+		{
+			code: '<span data-toggle="sidenav"></span>',
+			errors: [
+				{
+					messageId: 'noDataToggleSidenav',
+					type: 'JSXAttribute',
+				},
+			],
+		},
+		{
+			code: '<span data-toggle="    sidenav    "></span>',
+			errors: [
+				{
+					messageId: 'noDataToggleSidenav',
+					type: 'JSXAttribute',
+				},
+			],
+		},
+	],
+});

--- a/portal.js
+++ b/portal.js
@@ -1,0 +1,24 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+'use strict';
+
+const local = require('./utils/local');
+
+const config = {
+	extends: [require.resolve('./index')],
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+	plugins: [local('liferay-portal')],
+	rules: {
+		'liferay-portal/no-side-navigation': 'error',
+	},
+};
+
+module.exports = config;


### PR DESCRIPTION
My previous PR (#43) showed how to add a generic rule that we apply everywhere (both inside liferay-portal and in our open source repos).

This PR shows how we add rules specific to liferay-portal; it:

- Bundles a new "eslint-plugin-liferay-portal" inside this package.
- Adds a "liferay-portal/no-side-navigation" rule.
- Adds a new preset config "liferay/portal" (joining the "liferay/react" variant that we already had), which uses the new rule.