### PR TITLE
fix(no-it-should): anchor "should" pattern to start of string

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
@@ -32,7 +32,7 @@ module.exports = {
 						argument &&
 						argument.type === 'Literal' &&
 						typeof argument.value === 'string' &&
-						argument.value.match(/\s*should/)
+						argument.value.match(/^\s*should/)
 					) {
 						context.report({
 							message: DESCRIPTION,

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
@@ -14,6 +14,9 @@ ruleTester.run('no-it-should', rule, {
 		{
 			code: 'it("behaves")',
 		},
+		{
+			code: `it('has a checkbox with label "should notify"')`,
+		},
 	],
 
 	invalid: [


### PR DESCRIPTION
The initial version of this regex was a little too aggressive. While it's true that something like:

```javascript
it('is green and should stay green after clicking')
```

could be rewritten without the inner "should":

```javascript
it('is green and stays green after clicking')
```

we don't want to rule out legitmate "should" like the one I added to the test suite in this commit:

```javascript
it('has a checkbox with label "should notify"')
```

(Sure, we could also add an option for this, but let's keep things simple.)