### PR TITLE
feat: make notice/notice plugin work in liferay-portal projects

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const local = require('./utils/local');
 
 const config = {
@@ -20,5 +22,24 @@ const config = {
 		'liferay-portal/no-side-navigation': 'error',
 	},
 };
+
+/**
+ * The standard configuration (in "./index") only looks for a template
+ * in the current working directory; here we make things work when run from a
+ * project directory of the form "modules/apps/foo/bar" in the liferay-portal
+ * repo.
+ */
+if (
+	path.basename(process.cwd()) !== 'modules' &&
+	path.basename(path.resolve('../../..')) === 'modules' &&
+	fs.existsSync('../../../copyright.js')
+) {
+	config.rules['notice/notice'] = [
+		'error',
+		{
+			templateFile: '../../../copyright.js',
+		},
+	];
+}
 
 module.exports = config;


### PR DESCRIPTION
The automatic insertion of the copyright.js header is based on finding the template file in the current working directory. Because `yarn` will always change to the directory containing the package.json file, this works even if you run the linter from a subdirectory.

However, in liferay-portal, we use workspaces, and product teams often work from inside their project directories (eg. "modules/apps/foo/bar"), and these contain "package.json" files. This means that if they run `yarn format` or `yarn checkFormat` from inside their project, we won't automatically fix or check copyright headers.

Here we add a special case to the "liferay/portal" preset to look for such a "copyright.js" file higher up in the hierarchy. Basically, if you are using the "liferay/portal" preset, are not already inside "modules", and there is a "modules" three levels up from you, and it contains "copyright.js", then it's a pretty safe bet that you're inside a project and we should be using that template.

In the case where you're in liferay-portal but at the top level, everything will work as before.
