### PR TITLE
feat: add "liferay/metal" preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ Or, for React projects inside liferay-portal, extend both `liferay/react` and `l
 }
 ```
 
+### metal-jsx
+
+For legacy projects inside liferay-portal that use [metal-jsx](https://www.npmjs.com/package/metal-jsx), we have a "metal" preset:
+
+```js
+{
+  "extends": ["liferay/portal", "liferay/metal"],
+  "rules": {
+    // Additional, per-project rules...
+  }
+}
+```
+
+Use this preset to stop ESLint from [spuriously warning that variables that are used as JSX components are unused](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md).
+
 ### Copyright headers
 
 The included [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugin-notice) plug-in can be used to enforce the use of uniform copyright headers across a project by placing a template named `copyright.js` in the project root (for example, see [the file defining the headers used in eslint-config-liferay itself](https://github.com/liferay/eslint-config-liferay/blob/master/copyright.js)).

--- a/metal.js
+++ b/metal.js
@@ -1,0 +1,30 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+'use strict';
+
+const config = {
+	extends: [require.resolve('./index')],
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+	plugins: ['react'],
+	rules: {
+		/**
+		 * @see https://github.com/yannickcr/eslint-plugin-react
+		 */
+		'react/jsx-uses-vars': 'error',
+	},
+	settings: {
+		react: {
+			version: 'detect',
+		},
+	},
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"files": [
 		".eslintrc.js",
 		"index.js",
+		"metal.js",
 		"plugins",
 		"portal.js",
 		"react.js",


### PR DESCRIPTION
In a project like dynamic-data-mapping-form-builder, we use metal-jsx. For reasons described here:

https://eslint.org/blog/2015/03/eslint-0.17.0-released#changes-to-jsxreact-handling

ESLint will spuriously warn that variables that are only used as components inside JSX are not used. We can't just turn on the "liferay/react" preset in these projects because that includes a bunch of rules that don't make sense in a metal-jsx context.

So, we create a metal-specific preset here that contains just one rule:

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md

Switching to this preset makes all 23 currently-existing lint errors/warnings in the dynamic-data-mapping-form-builder project go away, as seen in these two before-and-after runs:

https://gist.github.com/wincent/16428f82e4ce74f8f5d6f73271ef1aef

The one remaining problem will be projects that use a mixture of metal-jsx and React (@andresfulla is currently dealing with one of those); we'll have to figure out what to do there along the way.

Test plan: `yarn add` the package to liferay-portal, create an `.eslintrc.js` as described in the README, and run `yarn checkFormat`.