### PR TITLE
feat: add liferay-portal/no-explicit-extend rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plug
 
 The bundled `eslint-plugin-liferay-portal` plugin includes the following [rules](./plugins/eslint-plugin-liferay-portal/docs/rules):
 
+-   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary `extends: ["liferay/portal"]` configuration.
 -   [liferay-portal/no-side-navigation](./plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.
 
 ## License

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
@@ -1,0 +1,27 @@
+# Disallow unnecessary `extends: ["liferay/portal"]` configuration (no-explicit-extends)
+
+This rule guards against unnecessary inclusion of the "liferay/portal" configuration.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+// .eslintrc.js
+module.exports = {
+	extends: ['liferay/portal', 'liferay/react'],
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// .eslintrc.js
+module.exports = {
+	extends: ['liferay/react'],
+};
+```
+
+## Further Reading
+
+-   [eslint-config-liferay/#53](https://github.com/liferay/eslint-config-liferay/pull/53)

--- a/plugins/eslint-plugin-liferay-portal/index.js
+++ b/plugins/eslint-plugin-liferay-portal/index.js
@@ -6,6 +6,7 @@
 
 module.exports = {
 	rules: {
+		'no-explicit-extend': require('./lib/rules/no-explicit-extend'),
 		'no-side-navigation': require('./lib/rules/no-side-navigation'),
 	},
 };

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -1,0 +1,188 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const path = require('path');
+
+const DESCRIPTION = '`liferay/portal` applies automatically and can be omitted';
+
+/**
+ * Returns the corresponding Property if `node` is found to be inside an
+ * ObjectExpression like this:
+ *
+ *     {
+ *         extends: ['liferay/portal']
+ *     }   ^        ^----------------^
+ *         |                |
+ *         |               node      ^
+ *         |                         |
+ *         ^-------------------------^
+ *                      |
+ *                  property
+ */
+function extractFromObjectExpression(node) {
+	const maybeProperty = node.parent;
+
+	if (
+		maybeProperty &&
+		maybeProperty.type === 'Property' &&
+		maybeProperty.key &&
+		maybeProperty.key.type === 'Identifier' &&
+		maybeProperty.key.name === 'extends'
+	) {
+		return maybeProperty;
+	}
+}
+
+/**
+ * Returns the corresponding Literal if `node` is found to be inside an
+ * ArrayExpression like this:
+ *
+ *     {
+ *         extends: ['foo', 'liferay/portal', 'bar']
+ *     }                    ^--------------^
+ *                                 |
+ *                                node
+ *
+ * If `node` is not in an ArrayExpression, falls back to trying to locate it in
+ * an ObjectExpression like this:
+ *
+ *     {
+ *         extends: 'liferay/portal'
+ *     }            ^--------------^
+ *                         |
+ *                        node
+ */
+function extractFromArrayExpression(node) {
+	const maybeArray = node.parent;
+
+	if (maybeArray && maybeArray.type === 'ArrayExpression') {
+		const extracted = extractFromObjectExpression(maybeArray);
+
+		if (extracted) {
+			if (maybeArray.elements.length === 1) {
+				// Removing the node from the array would leave an empty array,
+				// so remove the entire property instead.
+				return extracted;
+			} else {
+				// Just remove the node from the array.
+				return node;
+			}
+		}
+	} else {
+		return extractFromObjectExpression(node);
+	}
+}
+
+function fix(elementOrProperty, context, fixer) {
+	const source = context.getSourceCode();
+
+	let items;
+	let start;
+
+	if (elementOrProperty.type === 'Property') {
+		items = elementOrProperty.parent.properties;
+
+		// Special case: when removing last property, kill all internal
+		// whitespace.
+		if (
+			items.length === 1 &&
+			elementOrProperty.parent &&
+			elementOrProperty.parent.type === 'ObjectExpression'
+		) {
+			return fixer.replaceText(elementOrProperty.parent, '{}');
+		}
+
+		start = elementOrProperty.parent.properties[0].range[0];
+	} else {
+		items = elementOrProperty.parent.elements;
+		start = elementOrProperty.parent.elements[0].range[0];
+	}
+
+	const removeIndex = items.indexOf(elementOrProperty);
+	const lastIndex = items.length - 1;
+	const removeLast = removeIndex === lastIndex;
+
+	const end = items[lastIndex].range[1];
+
+	// Remove array element or object property, preserving whitespace between
+	// items.
+	return fixer.replaceTextRange(
+		[start, end],
+		items.slice().reduce((text, item, index) => {
+			const atEnd = index === lastIndex;
+			const itemText = source.getText(item);
+
+			// When removing last item, we eat preceding
+			// whitespace. When removing other items we eat
+			// trailing whitespace.
+			const trailingWhitespace = atEnd
+				? ''
+				: source
+						.getText()
+						.slice(item.range[1], items[index + 1].range[0]);
+
+			if (index !== removeIndex) {
+				if (index + 1 === lastIndex && removeLast) {
+					text += itemText;
+				} else {
+					text += itemText + trailingWhitespace;
+				}
+			}
+
+			return text;
+		}, '')
+	);
+}
+
+module.exports = {
+	meta: {
+		docs: {
+			description: DESCRIPTION,
+			category: 'Best Practices',
+			recommended: false,
+			url: 'https://github.com/liferay/eslint-config-liferay/pull/53',
+		},
+		fixable: 'code',
+		messages: {
+			noExplicitExtend: DESCRIPTION,
+		},
+		schema: [],
+		type: 'problem',
+	},
+
+	create(context) {
+		const filename = path.basename(context.getFilename());
+
+		if (filename !== '.eslintrc.js') {
+			return {};
+		}
+
+		return {
+			Literal(node) {
+				if (node.value !== 'liferay/portal') {
+					return;
+				}
+
+				/**
+				 * Extract a removable node, which will either be a
+				 * 'liferay/portal' string literal, or an object property
+				 * containing the same.
+				 */
+				const extracted =
+					extractFromArrayExpression(node) ||
+					extractFromObjectExpression(node);
+
+				if (extracted) {
+					context.report({
+						fix: fixer => fix(extracted, context, fixer),
+						messageId: 'noExplicitExtend',
+						node,
+					});
+				}
+			},
+		};
+	},
+};

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -1,0 +1,252 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/no-explicit-extend');
+
+const ruleTester = new RuleTester();
+
+const filename = '/data/liferay-portal/modules/apps/a/b/.eslintrc.js';
+
+ruleTester.run('no-explicit-extend', rule, {
+	valid: [
+		{
+			code: `
+				module.exports = {
+					extends: ['liferay/react']
+				};
+			`,
+			filename,
+		},
+		{
+			code: `
+				module.exports = {
+					extends: 'liferay/react'
+				};
+			`,
+			filename,
+		},
+		{
+			code: `
+				module.exports = {
+					extends: []
+				};
+			`,
+			filename,
+		},
+		{
+			// Would be invalid, but not in an .eslintrc.js file.
+			code: `
+				module.exports = {
+					extends: 'liferay/portal'
+				};
+			`,
+			filename: '/tmp/not-an-eslintrc.js',
+		},
+	],
+
+	invalid: [
+		{
+			// As a naked string.
+			code: `
+				module.exports = {
+					extends: 'liferay/portal'
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {};
+			`,
+		},
+		{
+			// As a naked string before other configuration.
+			code: `
+				module.exports = {
+					extends: 'liferay/portal',
+					rules: []
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					rules: []
+				};
+			`,
+		},
+		{
+			// As a naked string in the middle of other configuration.
+			code: `
+				module.exports = {
+					preset: 'fancy',
+					extends: 'liferay/portal',
+					rules: []
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					preset: 'fancy',
+					rules: []
+				};
+			`,
+		},
+		{
+			// As a naked string after other configuration.
+			code: `
+				module.exports = {
+					debug: true,
+					extends: 'liferay/portal'
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					debug: true
+				};
+			`,
+		},
+		{
+			// At the beginning, on one line.
+			code: `
+				module.exports = {
+					extends: ['liferay/portal', 'liferay/react']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: ['liferay/react']
+				};
+			`,
+		},
+		{
+			// In the middle, on one line.
+			code: `
+				module.exports = {
+					extends: ['special', 'liferay/portal', 'liferay/react']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: ['special', 'liferay/react']
+				};
+			`,
+		},
+		{
+			// At the end, on one line.
+			code: `
+				module.exports = {
+					extends: ['liferay/react', 'liferay/portal']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: ['liferay/react']
+				};
+			`,
+		},
+		{
+			// Alone.
+			code: `
+				module.exports = {
+					extends: ['liferay/portal']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {};
+			`,
+		},
+		{
+			// Alone with a trailing comma.
+			code: `
+				module.exports = {
+					extends: ['liferay/portal'],
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {};
+			`,
+		},
+		{
+			// Alone with a trailing comma across multiple lines.
+			code: `
+				module.exports = {
+					extends: [
+						'liferay/portal',
+					],
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Literal',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {};
+			`,
+		},
+	],
+});

--- a/portal.js
+++ b/portal.js
@@ -19,6 +19,7 @@ const config = {
 	},
 	plugins: [local('liferay-portal')],
 	rules: {
+		'liferay-portal/no-explicit-extend': 'error',
 		'liferay-portal/no-side-navigation': 'error',
 	},
 };


### PR DESCRIPTION
I wanted to put this in the repo because it is an example of a liferay-portal-specific lint that:

- Only applies to certain files.
- Includes an "autofix" functionality.

Test plan:

Run this in liferay-portal without:

 https://github.com/brianchandotcom/liferay-portal/pull/75813

See:

    modules/apps/data-engine/data-engine-taglib/.eslintrc.js
      16:12  error  `liferay/portal` applies automatically and can be omitted  liferay-portal/no-explicit-extend

    modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js
      16:12  error  `liferay/portal` applies automatically and can be omitted  liferay-portal/no-explicit-extend

    modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js
      16:12  error  `liferay/portal` applies automatically and can be omitted  liferay-portal/no-explicit-extend

    modules/apps/layout/layout-content-page-editor-web/.eslintrc.js
      16:12  error  `liferay/portal` applies automatically and can be omitted  liferay-portal/no-explicit-extend

    modules/apps/segments/segments-web/.eslintrc.js
      16:12  error  `liferay/portal` applies automatically and can be omitted  liferay-portal/no-explicit-extend

    ✖ 5 problems (5 errors, 0 warnings)
      5 errors and 0 warnings potentially fixable with the `--fix` option.

    ESLint checked 562 files, found 5 errors, found 0 warnings, 5 issues potentially fixable with lint:fix

Which are the same files reported by `git grep 'extends:.+liferay'`:

    apps/app-builder/app-builder-web/.eslintrc.js:16:       extends: ['liferay/react']
    apps/data-engine/data-engine-taglib/.eslintrc.js:16:    extends: ['liferay/portal', 'liferay/metal']
    apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.eslintrc.js:16:    extends: ['liferay/portal', 'liferay/metal']
    apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.eslintrc.js:16:        extends: ['liferay/portal', 'liferay/metal']
    apps/layout/layout-content-page-editor-web/.eslintrc.js:16:     extends: ['liferay/portal', 'liferay/react'],
    apps/segments/segments-web/.eslintrc.js:16:     extends: ['liferay/portal', 'liferay/react']

After running autofix, see this diff:

https://gist.github.com/wincent/6874c549f011937104266800ab724475