### PR TITLE
feat!: enforce use of React fragment shorthand syntax

### DIFF
--- a/react.js
+++ b/react.js
@@ -24,6 +24,7 @@ const config = {
 		/**
 		 * @see https://github.com/yannickcr/eslint-plugin-react
 		 */
+		'react/jsx-fragments': 'error',
 		'react/jsx-key': 'error',
 		'react/jsx-no-comment-textnodes': 'error',
 		'react/jsx-no-duplicate-props': 'error',


### PR DESCRIPTION
Breaking because this may cause the linter to emit new errors.

Rule: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md

Closes: https://github.com/liferay/eslint-config-liferay/issues/57