### PR TITLE
feat: adds no-metal-plugins rule to avoid deprecated metal-* imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plug
 The bundled `eslint-plugin-liferay-portal` plugin includes the following [rules](./plugins/eslint-plugin-liferay-portal/docs/rules):
 
 -   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary `extends: ["liferay/portal"]` configuration.
+-   [liferay-portal/no-metal-plugins](./plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md): Prevents usage of deprecated `metal-*` plugins and utilities.
 -   [liferay-portal/no-side-navigation](./plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.
 
 ## License

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md
@@ -1,0 +1,69 @@
+# Disallow use of deprecated metal plugins (no-metal-plugins)
+
+This rule guards against the use of various deprecated metal plugins such as:
+
+-   [metal-ajax](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-ajax)
+-   [metal-aop](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-aop)
+-   [metal-clipboard](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-clipboard)
+-   [metal-debounce](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-debounce)
+-   [metal-keyboard-focus](https://github.com/metal/metal-keyboard-focus)
+-   [metal-promise](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-promise)
+-   [metal-storage](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-storage)
+-   [metal-structs](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-structs)
+-   [metal-uri](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-uri)
+-   [metal-useragent](https://github.com/metal/metal-plugins/tree/eabc06702f498722ca3c32f0d19f441c14221d1d/packages/metal-useragent)
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+import Ajax from 'metal-ajax';
+
+import {AOP} from 'metal-aop';
+
+import Clipboard from 'metal-clipboard';
+
+import {debounce} from 'metal-debounce';
+
+import KeyboardFocusManager from 'metal-keyboard-focus';
+
+import {CancellablePromise} from 'metal-promise';
+
+import {LocalStorageMechanism, Storage} from 'metal-storage';
+
+import {MultiMap} from 'metal-structs';
+
+import URI from 'metal-uri';
+
+import UA from 'metal-useragent';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import {fetch} from 'frontend-js-web';
+import {AOP} from 'frontend-js-web';
+import ClipboardJS from 'clipboard';
+import {debounce} from 'frontend-js-web';
+import {KeyboardFocusManager} from 'frontend-js-web';
+```
+
+## Further Reading
+
+-   [LPS-96715 Streamline Metal usage in Liferay Portal (Part I)](https://issues.liferay.com/browse/LPS-96715)
+-   [LPS-96717 Link frontend-js-web dependencies](https://issues.liferay.com/browse/LPS-96717)
+-   [LPS-96718 Include metal-aop inside liferay-portal](https://issues.liferay.com/browse/LPS-96718)
+-   [LPS-96719 Include metal-ajax inside liferay-portal](https://issues.liferay.com/browse/LPS-96719)
+-   [LPS-96720 Include metal-promise inside liferay-portal](https://issues.liferay.com/browse/LPS-96720)
+-   [LPS-96722 Include metal-clipboard inside liferay-portal](https://issues.liferay.com/browse/LPS-96722)
+-   [LPS-96723 Include metal-debounce inside liferay-portal](https://issues.liferay.com/browse/LPS-96723)
+-   [LPS-96724 Include metal-keyboard-focus inside liferay-portal](https://issues.liferay.com/browse/LPS-96724)
+-   [LPS-96725 Include metal-storage inside liferay-portal](https://issues.liferay.com/browse/LPS-96725)
+-   [LPS-96726 Include metal-structs inside liferay-portal](https://issues.liferay.com/browse/LPS-96726)
+-   [LPS-96727 Replace metal-uri with URL in liferay-portal](https://issues.liferay.com/browse/LPS-96727)
+-   [LPS-96728 Include metal-user-agent inside liferay-portal](https://issues.liferay.com/browse/LPS-96728)
+-   [LPS-96766 Configure ESLint to warn about use of deprecated metal-\* plugins](https://issues.liferay.com/browse/LPS-96766)
+-   [LPS-96777 Replace Promise with async/await](https://issues.liferay.com/browse/LPS-96777)
+-   [LPS-99236 Remove metal-clipboard from liferay-portal](https://issues.liferay.com/browse/LPS-99236)
+-   [LPS-99416 Update senna to version 3.0.0-milestone.1](https://issues.liferay.com/browse/LPS-99416)

--- a/plugins/eslint-plugin-liferay-portal/index.js
+++ b/plugins/eslint-plugin-liferay-portal/index.js
@@ -7,6 +7,7 @@
 module.exports = {
 	rules: {
 		'no-explicit-extend': require('./lib/rules/no-explicit-extend'),
+		'no-metal-plugins': require('./lib/rules/no-metal-plugins'),
 		'no-side-navigation': require('./lib/rules/no-side-navigation'),
 	},
 };

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
@@ -1,0 +1,79 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const DEPRECATED_MODULES = [
+	'metal-ajax',
+	'metal-aop',
+	'metal-clipboard',
+	'metal-debounce',
+	'metal-keyboard-focus',
+	'metal-promise',
+	'metal-storage',
+	'metal-structs',
+	'metal-uri',
+	'metal-useragent',
+];
+
+const toCamelCase = input => {
+	return input
+		.replace(/^[_.\- ]+/, '')
+		.toLowerCase()
+		.replace(/[_.\- ]+(\w|$)/g, (_, p1) => p1.toUpperCase())
+		.replace(/\d+(\w|$)/g, m => m.toUpperCase());
+};
+
+module.exports = {
+	meta: {
+		docs: {
+			description:
+				'metal-plugins are deprecated; use local utilities instead',
+			category: 'Deprecated APIs',
+			recommended: false,
+			url: 'https://issues.liferay.com/browse/LPS-96715',
+		},
+		fixable: null,
+		messages: {
+			noMetalAjax:
+				"metal-ajax is deprecated; use `import {fetch} from 'frontend-js-web';` instead",
+			noMetalAop:
+				"metal-aop is deprecated; use `import {AOP} from 'frontend-js-web';` instead",
+			noMetalClipboard:
+				'metal-clipboard is deprecated; use ClipboardJS instead',
+			noMetalDebounce:
+				"metal-debounce is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
+			noMetalKeyboardFocus:
+				"metal-keyboard-focus is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
+			noMetalPromise:
+				'metal-promise is deprecated; use native Promise instead',
+			noMetalStorage:
+				'metal-storage is deprecated; use a local implementation instead',
+			noMetalStructs:
+				'metal-structs is deprecated; use plain objects instead',
+			noMetalUri: 'metal-uri is deprecated; use native URL instead',
+			noMetalUseragent:
+				'metal-useragent is deprecated; use `Liferay.Browser` instead',
+		},
+		schema: [],
+		type: 'problem',
+	},
+
+	create(context) {
+		return {
+			ImportDeclaration(node) {
+				if (
+					node.source &&
+					node.source.type === 'Literal' &&
+					DEPRECATED_MODULES.includes(node.source.value)
+				) {
+					context.report({
+						messageId: toCamelCase(`no-${node.source.value}`),
+						node,
+					});
+				}
+			},
+		};
+	},
+};

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
@@ -17,14 +17,6 @@ const DEPRECATED_MODULES = [
 	'metal-useragent',
 ];
 
-const toCamelCase = input => {
-	return input
-		.replace(/^[_.\- ]+/, '')
-		.toLowerCase()
-		.replace(/[_.\- ]+(\w|$)/g, (_, p1) => p1.toUpperCase())
-		.replace(/\d+(\w|$)/g, m => m.toUpperCase());
-};
-
 module.exports = {
 	meta: {
 		docs: {
@@ -36,24 +28,24 @@ module.exports = {
 		},
 		fixable: null,
 		messages: {
-			noMetalAjax:
+			'no-metal-ajax':
 				"metal-ajax is deprecated; use `import {fetch} from 'frontend-js-web';` instead",
-			noMetalAop:
+			'no-metal-aop':
 				"metal-aop is deprecated; use `import {AOP} from 'frontend-js-web';` instead",
-			noMetalClipboard:
+			'no-metal-clipboard':
 				'metal-clipboard is deprecated; use ClipboardJS instead',
-			noMetalDebounce:
+			'no-metal-debounce':
 				"metal-debounce is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
-			noMetalKeyboardFocus:
+			'no-metal-keyboard-focus':
 				"metal-keyboard-focus is deprecated; use `import {debounce} from 'frontend-js-web';` instead",
-			noMetalPromise:
+			'no-metal-promise':
 				'metal-promise is deprecated; use native Promise instead',
-			noMetalStorage:
+			'no-metal-storage':
 				'metal-storage is deprecated; use a local implementation instead',
-			noMetalStructs:
+			'no-metal-structs':
 				'metal-structs is deprecated; use plain objects instead',
-			noMetalUri: 'metal-uri is deprecated; use native URL instead',
-			noMetalUseragent:
+			'no-metal-uri': 'metal-uri is deprecated; use native URL instead',
+			'no-metal-useragent':
 				'metal-useragent is deprecated; use `Liferay.Browser` instead',
 		},
 		schema: [],
@@ -69,7 +61,7 @@ module.exports = {
 					DEPRECATED_MODULES.includes(node.source.value)
 				) {
 					context.report({
-						messageId: toCamelCase(`no-${node.source.value}`),
+						messageId: `no-${node.source.value}`,
 						node,
 					});
 				}

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
@@ -1,0 +1,114 @@
+/**
+ * © 2017 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/no-metal-plugins');
+
+const parserOptions = {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+};
+
+const ruleTester = new RuleTester(parserOptions);
+
+ruleTester.run('no-metal-plugins', rule, {
+	valid: [],
+	invalid: [
+		{
+			code: "import Ajax from 'metal-ajax';",
+			errors: [
+				{
+					messageId: 'noMetalAjax',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {AOP} from 'metal-aop';",
+			errors: [
+				{
+					messageId: 'noMetalAop',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import Clipboard from 'metal-clipboard';",
+			errors: [
+				{
+					messageId: 'noMetalClipboard',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {debounce} from 'metal-debounce';",
+			errors: [
+				{
+					messageId: 'noMetalDebounce',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import KeyboardFocusManager from 'metal-keyboard-focus';",
+			errors: [
+				{
+					messageId: 'noMetalKeyboardFocus',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {CancellablePromise} from 'metal-promise';",
+			errors: [
+				{
+					messageId: 'noMetalPromise',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code:
+				"import {LocalStorageMechanism, Storage} from 'metal-storage';",
+			errors: [
+				{
+					messageId: 'noMetalStorage',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import {MultiMap} from 'metal-structs';",
+			errors: [
+				{
+					messageId: 'noMetalStructs',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import URI from 'metal-uri';",
+			errors: [
+				{
+					messageId: 'noMetalUri',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+		{
+			code: "import UA from 'metal-useragent';",
+			errors: [
+				{
+					messageId: 'noMetalUseragent',
+					type: 'ImportDeclaration',
+				},
+			],
+		},
+	],
+});

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
@@ -23,7 +23,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import Ajax from 'metal-ajax';",
 			errors: [
 				{
-					messageId: 'noMetalAjax',
+					messageId: 'no-metal-ajax',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -32,7 +32,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import {AOP} from 'metal-aop';",
 			errors: [
 				{
-					messageId: 'noMetalAop',
+					messageId: 'no-metal-aop',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -41,7 +41,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import Clipboard from 'metal-clipboard';",
 			errors: [
 				{
-					messageId: 'noMetalClipboard',
+					messageId: 'no-metal-clipboard',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -50,7 +50,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import {debounce} from 'metal-debounce';",
 			errors: [
 				{
-					messageId: 'noMetalDebounce',
+					messageId: 'no-metal-debounce',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -59,7 +59,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import KeyboardFocusManager from 'metal-keyboard-focus';",
 			errors: [
 				{
-					messageId: 'noMetalKeyboardFocus',
+					messageId: 'no-metal-keyboard-focus',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -68,7 +68,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import {CancellablePromise} from 'metal-promise';",
 			errors: [
 				{
-					messageId: 'noMetalPromise',
+					messageId: 'no-metal-promise',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -78,7 +78,7 @@ ruleTester.run('no-metal-plugins', rule, {
 				"import {LocalStorageMechanism, Storage} from 'metal-storage';",
 			errors: [
 				{
-					messageId: 'noMetalStorage',
+					messageId: 'no-metal-storage',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -87,7 +87,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import {MultiMap} from 'metal-structs';",
 			errors: [
 				{
-					messageId: 'noMetalStructs',
+					messageId: 'no-metal-structs',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -96,7 +96,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import URI from 'metal-uri';",
 			errors: [
 				{
-					messageId: 'noMetalUri',
+					messageId: 'no-metal-uri',
 					type: 'ImportDeclaration',
 				},
 			],
@@ -105,7 +105,7 @@ ruleTester.run('no-metal-plugins', rule, {
 			code: "import UA from 'metal-useragent';",
 			errors: [
 				{
-					messageId: 'noMetalUseragent',
+					messageId: 'no-metal-useragent',
 					type: 'ImportDeclaration',
 				},
 			],

--- a/portal.js
+++ b/portal.js
@@ -20,6 +20,7 @@ const config = {
 	plugins: [local('liferay-portal')],
 	rules: {
 		'liferay-portal/no-explicit-extend': 'error',
+		'liferay-portal/no-metal-plugins': 'error',
 		'liferay-portal/no-side-navigation': 'error',
 	},
 };


### PR DESCRIPTION
This is a naive first pass at a rule for deprecated `metal-*` imports.

I originally added some other checks like usage of `CancellablePromise` but I figure that after all, once we remove the `import` its usages will get flagged in different ways, so there's probably no need to go any further.