### PR TITLE
feat!: enables sort-keys rule to make sure keys are sorted alphabetically in ascending order

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const config = {
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
 		'quote-props': ['error', 'as-needed'],
+		'sort-keys': ['error', 'asc', {caseSensitive: false}],
 	},
 };
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const config = {
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
 		'quote-props': ['error', 'as-needed'],
-		'sort-keys': ['error', 'asc', {caseSensitive: false}],
+		'sort-keys': ['error', 'asc', {caseSensitive: false, natural: true}],
 	},
 };
 


### PR DESCRIPTION
This will be a breaking change as it will result in more errors. Right now, if applied to portal, we get:

```
✖ 150 problems (150 errors, 0 warnings)
```