### PR TITLE
feat!: activate the "radix" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const config = {
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
 		'quote-props': ['error', 'as-needed'],
+		radix: 'error',
 		'sort-keys': ['error', 'asc', {caseSensitive: true, natural: true}],
 	},
 };


### PR DESCRIPTION
If we can't safely use `parseInt(foo)` *everywhere*, we should probably use it *nowhere*. Let's just use `parseInt(foo, 10)` consistently.

See: https://eslint.org/docs/rules/radix