### PR TITLE
docs: flesh out the no-react-dom-render docs

### DIFF
--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md
@@ -1,6 +1,13 @@
 # Disallow direct use of `ReactDOM.render` (no-react-dom-render)
 
-This rule guards against the direct use of the `ReactDOM.render` API, in favor of our [custom `render` wrapper](https://github.com/brianchandotcom/liferay-portal/pull/77218) implemented in `frontend-js-react-web`.
+This rule guards against the direct use of the `ReactDOM.render` API, in favor of our [custom `render` wrapper](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js) implemented in `frontend-js-react-web`.
+
+At the time of writing, the wrapper provides:
+
+-   Automatic unmounting in response to "destroyPortlet" events.
+-   Transparent provision of the `ClayIconSpriteContext` needed by Clay.
+
+If you'd like to propose further useful additions, please [create an issue](https://github.com/liferay/liferay-frontend-guidelines/issues/new) in the [liferay-frontend-guidelines](https://github.com/liferay/liferay-frontend-guidelines) repo.
 
 ## Rule Details
 


### PR DESCRIPTION
- Update the link to point to the current implementation instead of the initial pull.
- Explain why we use a wrapper and what it does.