### PR TITLE
fix: always resolve "eslint" relative to $PWD

### DIFF
--- a/utils/local.js
+++ b/utils/local.js
@@ -39,7 +39,10 @@ function patch() {
 
 	if (majorVersion > 5) {
 		if (!originalResolve) {
-			const resolver = require('eslint/lib/shared/relative-module-resolver');
+			const resolver = require(require.resolve(
+				'eslint/lib/shared/relative-module-resolver',
+				{paths: [process.cwd()]}
+			));
 
 			originalResolve = resolver.resolve;
 


### PR DESCRIPTION
eslint-config-liferay has an exact "devDependency" on eslint (currently 6.2.2). This makes it very easy to wind up with a local version that does not match the version being used in a parent project that uses "eslint-config-liferay".

This in turn can lead to a structure like this:

    parent-project/               (uses eslint v6.2.2)
       node_modules/
        eslint                    (6.2.2)
        eslint-config-liferay/
          node_modules/
            eslint                (6.1.0)

So, when we try to do our sneaky monkey patching inside eslint-config-liferay, we wind up patching the nested v6.1.0 version instead of the one that is actually being used at run time, the v6.2.2 version.

This in turn means that we'll see errors like this:

    ESLint couldn't find the plugin "eslint-plugin-liferay".

The fix is to always perform the resolution from the perspective of the parent project.