### PR TITLE
feat: turn off no-control-regex rule (#80)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const config = {
 		'liferay/no-it-should': 'error',
 		'liferay/padded-test-blocks': 'error',
 		'no-console': ['error', {allow: ['warn', 'error']}],
+		'no-control-regex': 'off',
 		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-only-tests/no-only-tests': 'error',
 		'no-return-assign': ['error', 'always'],


### PR DESCRIPTION
It's in the "eslint:recommended" set but the probability of it catching an actual bug seems vanishingly small, and we have at least one apparently-legitimate-or-at-least-not-an-actual-bug use of a control characters in a regex.

See: https://eslint.org/docs/rules/no-control-regex

Closes: https://github.com/liferay/eslint-config-liferay/issues/80