### PR TITLE
feat: turn off checkLoops in no-constant-condition rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const config = {
 		'liferay/no-it-should': 'error',
 		'liferay/padded-test-blocks': 'error',
 		'no-console': ['error', {allow: ['warn', 'error']}],
+		'no-constant-condition': ['error', {checkLoops: false}],
 		'no-control-regex': 'off',
 		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-only-tests/no-only-tests': 'error',


### PR DESCRIPTION
Disabling [checkLoops in the no-constant-conditions](https://eslint.org/docs/rules/no-constant-condition#checkloops) rule allows us to do things like:

```javascript
while(true) {
    if (condition) {
        break;
    }
}
```

Additionally, we could also do

```javascript
while(true) {
    // Do nothing, just hang in there
}
```

But we can leave that up to our developers, I guess :)