### PR TITLE
feat!: Enables prefer-arrow-callback allowing named functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const config = {
 		'no-unused-expressions': 'error',
 		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'object-shorthand': 'error',
+		'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
 		'prefer-const': 'error',
 		'quote-props': ['error', 'as-needed'],
 		radix: 'error',


### PR DESCRIPTION
Enables `prefer-arrow-callback` but with `allowNamedFunctions: true`.

Running this in portal says:

```
ESLint checked 1006 files, found 0 errors, found 0 warnings, fixed issues in 213 files
Prettier checked 1612 files, fixed 194 files
```

https://github.com/jbalsas/liferay-portal/pull/1924/files