### PR TITLE
feat!: Enables prefer-object-spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const config = {
 		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'object-shorthand': 'error',
 		'prefer-const': 'error',
+		'prefer-object-spread': 'error',
 		'quote-props': ['error', 'as-needed'],
 		radix: 'error',
 		'sort-keys': ['error', 'asc', {caseSensitive: true, natural: true}],


### PR DESCRIPTION
Enables `prefer-object-spread`.

Missing some places that are probably a different type of smell:

```
Chema-Balsas% git grep Object.assign -- "**/*.js"
dynamic-data-mapping/dynamic-data-mapping-form-builder/npmscripts.config.js:module.exports = Object.assign(standard, {
dynamic-data-mapping/dynamic-data-mapping-form-builder/npmscripts.config.js:    build: Object.assign(standard.build, {
dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js:                         Object.assign(child.props, {
frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js:                          return Object.assign(actionItem, {
layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/LayoutColumn.es.js:             return Object.assign(state, {
layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/components/toolbar/SegmentsExperienceSelector.es.js:                     this._segmentsExperienceErrors = Object.assign(
map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js:                       Object.assign(mapConfig, controlsConfig)
map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js:                  Object.assign(mapConfig, controlsConfig)
segments/segments-web/src/main/resources/META-INF/resources/js/utils/utils.es.js:       return Object.assign(list, {
sharing/sharing-web/src/main/resources/META-INF/resources/ManageCollaborators.es.js:                                                    throw Object.assign(error, {response});
sharing/sharing-web/src/main/resources/META-INF/resources/Sharing.es.js:                                                                throw Object.assign(error, {response});
```

https://github.com/jbalsas/liferay-portal/pull/1925