### PR TITLE
docs: add missing docs for padded-test-blocks rule

### DIFF
--- a/plugins/eslint-plugin-liferay/docs/rules/padded-test-blocks.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/padded-test-blocks.md
@@ -1,0 +1,43 @@
+# Consecutive test blocks (eg. `it()` etc) should be separated by a blank line (padded-test-blocks)
+
+This rule enforces that `it()` calls and other test blocks are separated by a blank line.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+describe('thing', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+	it('is red', () => {
+		// ...
+	});
+	it('is loud', () => {
+		// ...
+	});
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+describe('thing', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('is red', () => {
+		// ...
+	});
+
+	it('is loud', () => {
+		// ...
+	});
+});
+```
+
+## Further Reading
+
+-   [#65](https://github.com/liferay/eslint-config-liferay/issues/65)


### PR DESCRIPTION
I had these on my personal laptop and forgot to include them with the original work on this rule.