### PR TITLE
fix: make local `patch()` work in edge-case scenario

### DIFF
--- a/utils/local.js
+++ b/utils/local.js
@@ -34,7 +34,11 @@ let originalResolve;
  * https://github.com/eslint/eslint/commit/6ae21a4bfe5a
  */
 function patch() {
-	const match = require('eslint/package.json').version.match(/^(\d+)/);
+	const eslint = require.resolve('eslint/package.json', {
+		paths: [process.cwd()],
+	});
+	const version = JSON.parse(fs.readFileSync(eslint, 'utf8')).version;
+	const match = version.match(/^(\d+)/);
 	const majorVersion = match ? parseInt(match[1], 10) : 0;
 
 	if (majorVersion > 5) {


### PR DESCRIPTION
I was doing some quick-and-dirty testing in liferay-js-themes-toolkit like this:

    cp -r ~/code/eslint-config-liferay node_modules

And I found that our monkey patching wasn't working there because that project has an ESLint dependency of "^5.15.2" while eslint-config-liferay itself has a dependency of "6.1.0". So, you wind up with this structure:

    node_modules/eslint (5.16.0)
    node_modules/eslint-config-liferay/node_modules/eslint (6.1.0)

liferay-js-themes-toolkit runs using the `eslint` executable, but whenwe get into the `patch()` code and do our `require()`, we wind up seeing the local 6.1.0 version instead of the 5.16.0 version that the project is actually using. We thus attempt to monkey-patch the wrong code.

Solution is to make sure we always look for and load the project's own ESLint version instead of our local one.

This is all a bit edge-casey, I think, because even if you `npm install --save eslint-config-liferay` to a project, you don't get its devDependencies and so you wouldn't get the nested ESLint dependency; I only got it because I was doing my testing with `cp`. Still, this is something I want to fix so that I can easily do these kind of quick tests without having to worry about it.

Test plan: `cp` this change over to liferay-js-themes-toolkit and liferay-portal` and see that linting works.