### PR TITLE
fix: avoid deprecation warning

### DIFF
--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
@@ -12,13 +12,11 @@ const parserOptions = {
 	ecmaFeatures: {
 		jsx: true,
 	},
-	parserOptions: {
-		ecmaVersion: 6,
-		sourceType: 'module',
-	},
+	ecmaVersion: 6,
+	sourceType: 'module',
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new RuleTester({parserOptions});
 
 const errors = [
 	{


### PR DESCRIPTION
Avoids this console warning during the test run:

    [ESLINT_LEGACY_ECMAFEATURES] DeprecationWarning: The 'ecmaFeatures'
    config file property is deprecated, and has no effect. (found in
    "rule-tester")

`ecmaFeatures` still exists, but it is supposed to be nested inside `parserOptions`.