### PR TITLE
fix(imports-first): solve problems with directives

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/common/imports.js
+++ b/plugins/eslint-plugin-liferay/lib/common/imports.js
@@ -154,7 +154,7 @@ function isRelative(source) {
  * See also `getRequireStatement()` in this module.
  */
 function isRequireStatement(node) {
-	if (!node && node.type !== 'VariableDeclaration') {
+	if (!node || node.type !== 'VariableDeclaration') {
 		return false;
 	}
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
@@ -49,6 +49,42 @@ ruleTester.run('imports-first', rule, {
 				},
 			],
 		},
+		{
+			// Regression test: the second require here wasn't being flagged
+			// because we were choking (silently) on the directive:
+			code: `
+				'use strict';
+
+				var {Gulp} = require('gulp');
+
+				var gulp = new Gulp();
+
+				var {getArgv} = require('../../lib/util');
+			`,
+			errors: [
+				{
+					message:
+						'import of "../../lib/util" must come before other statements',
+					type: 'VariableDeclaration',
+				},
+			],
+		},
+		{
+			// Note that directives are only ignored when they are at the top.
+			code: `
+				const a = require('a');
+
+				'use strict';
+
+				const x = require('x');
+			`,
+			errors: [
+				{
+					message: 'import of "x" must come before other statements',
+					type: 'VariableDeclaration',
+				},
+			],
+		},
 	],
 
 	valid: [
@@ -94,6 +130,14 @@ ruleTester.run('imports-first', rule, {
 				const replace = require('gulp-replace-task');
 				const through = require('through2');
 				const PluginError = require('plugin-error');
+			`,
+		},
+		{
+			code: `
+				'use strict';
+
+				const a = require('a');
+				const b = require('b');
 			`,
 		},
 	],


### PR DESCRIPTION
We had two problems with respect to directives:

```js
'use strict';

var x = require('x');
```
One was a logic error: we would walk up looking at tokens and checking them with `isRequireStatement()`; on reaching the directive the conditional here was broken, so we'd end up trying to destructure `init` from `node.declarations`, which was undefined.

So, we fix that bug, and doing that reveals some false positive lints because now they complain about imports not being before directives. This requires us to add some logic to allow directives at the top of the file without triggering the "imports-first" rule. Bogus "directives" (ie. a "use strict" not actually at the top of the file) are handled correctly; that is, imports after those do trigger an error, as shown in the tests.
