### PR TITLE
fix(imports-first): turn on imports-first by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const config = {
 		'default-case': 'error',
 		'liferay/destructure-requires': 'error',
 		'liferay/group-imports': 'error',
+		'liferay/imports-first': 'error',
 		'liferay/no-absolute-import': 'error',
 		'liferay/no-duplicate-imports': 'error',
 		'liferay/no-dynamic-require': 'error',


### PR DESCRIPTION
This was supposed to be on by default but it wasn't. Discovered while testing in liferay-js-themes-toolkit.