### PR TITLE
feat: bump ecmaVersion to 2018

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const config = {
 	},
 	extends: ['eslint:recommended', require.resolve('eslint-config-prettier')],
 	parserOptions: {
-		ecmaVersion: 2017,
+		ecmaVersion: 2018,
 		sourceType: 'module',
 	},
 	plugins: [


### PR DESCRIPTION
This is what we are using pretty much everywhere at this point: we already have this setting explicitly set to 2018 in these places:

- alloy-editor
- eslint-config-liferay (ie. this repo!)
- liferay-frontend-guidelines
- liferay-js-themes-toolkit
- liferay-npm-tools

Adding it here means we can delete it from those 5 places in the future (once they've updated to the new version of eslint-config-liferay).

Noticed this because @FabioDiegoMastrorilli was asking why he needed to add:

    parserOptions: {
        ecmaFeatures: {
            experimentalObjectRestSpread: true
        }
    },

in another project that was using the config.