### PR TITLE
feat: update the no-react-dom-render error message

### DIFF
--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-react-dom-render.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-react-dom-render.js
@@ -7,7 +7,8 @@
 /* eslint-disable no-for-of-loops/no-for-of-loops */
 
 const DESCRIPTION =
-	'Direct use of ReactDOM.render is discouraged; instead: ' +
+	'Direct use of ReactDOM.render is discouraged; instead, use ' +
+	'the <react:component /> JSP taglib, or do: ' +
 	`import {render} from 'frontend-js-react-web';`;
 
 module.exports = {


### PR DESCRIPTION
When we originally added this rule, we didn't have the `<react:component />` taglib yet. Now, we do, so we should mention it in the error message. I put it first in the message, before mentioning `react` from "frontend-js-react-web", because I get the sense we'd like to encourage use of the taglib.

Closes: https://github.com/liferay/eslint-config-liferay/issues/81