### PR TITLE
docs: regenerate CHANGELOG.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,3 @@
 
 # We don't want Prettier to strip the trailing blank line.
 /copyright.js
-
-# Generated file.
-/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 -   feat: update the no-react-dom-render error message ([\#105](https://github.com/liferay/eslint-config-liferay/pull/105))
 -   fix: make no-it-should rule case-insensitive ([\#104](https://github.com/liferay/eslint-config-liferay/pull/104))
 
+## [v11.1.0](https://github.com/liferay/eslint-config-liferay/tree/v11.1.0) (2019-09-27)
+
+[Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v11.0.1...v11.1.0)
+
+-   feat: bump ecmaVersion to 2018 ([\#102](https://github.com/liferay/eslint-config-liferay/pull/102))
+
 ## [v11.0.1](https://github.com/liferay/eslint-config-liferay/tree/v11.0.1) (2019-09-24)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v11.0.0...v11.0.1)
@@ -40,176 +46,181 @@
 
 -   feat: allows '../fetch.es' local default imports for the no-global-fetch rule ([\#86](https://github.com/liferay/eslint-config-liferay/pull/86))
 -   docs: advise to use liferay-changelog-generator in CONTRIBUTING.md ([\#85](https://github.com/liferay/eslint-config-liferay/pull/85))
--   feat!: removes $ and \_ from globals to flag unwanted usage ([\#84](https://github.com/liferay/eslint-config-liferay/pull/84))
+-   feat!: removes \$ and \_ from globals to flag unwanted usage ([\#84](https://github.com/liferay/eslint-config-liferay/pull/84))
 
 ## [v8.1.0](https://github.com/liferay/eslint-config-liferay/tree/v8.1.0) (2019-09-04)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v8.0.0...v8.1.0)
 
-- feat: turn off checkLoops in no-constant-condition rule ([\#83](https://github.com/liferay/eslint-config-liferay/pull/83))
-- feat: turn off no-control-regex rule (#80) ([\#82](https://github.com/liferay/eslint-config-liferay/pull/82))
-- feat!: activate "no-console" rule ([\#79](https://github.com/liferay/eslint-config-liferay/pull/79))
-- fix: always resolve "eslint" relative to $PWD ([\#78](https://github.com/liferay/eslint-config-liferay/pull/78))
-- feat: add padded-test-blocks ([\#75](https://github.com/liferay/eslint-config-liferay/pull/75))
-- docs: flesh out the no-react-dom-render docs ([\#76](https://github.com/liferay/eslint-config-liferay/pull/76))
+-   feat: turn off checkLoops in no-constant-condition rule ([\#83](https://github.com/liferay/eslint-config-liferay/pull/83))
+-   feat: turn off no-control-regex rule (#80) ([\#82](https://github.com/liferay/eslint-config-liferay/pull/82))
+-   feat!: activate "no-console" rule ([\#79](https://github.com/liferay/eslint-config-liferay/pull/79))
+-   fix: always resolve "eslint" relative to \$PWD ([\#78](https://github.com/liferay/eslint-config-liferay/pull/78))
+-   feat: add padded-test-blocks ([\#75](https://github.com/liferay/eslint-config-liferay/pull/75))
+-   docs: flesh out the no-react-dom-render docs ([\#76](https://github.com/liferay/eslint-config-liferay/pull/76))
 
 ## [v8.0.0](https://github.com/liferay/eslint-config-liferay/tree/v8.0.0) (2019-08-21)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v7.0.0...v8.0.0)
 
-- feat: add liferay-portal/no-react-dom-render rule ([\#71](https://github.com/liferay/eslint-config-liferay/pull/71))
-- feat: configure Semantic Pull Requests bot ([\#73](https://github.com/liferay/eslint-config-liferay/pull/73))
-- fix: repair broken link in no-it-should rule ([\#72](https://github.com/liferay/eslint-config-liferay/pull/72))
-- docs: provide links to justify rule choices ([\#68](https://github.com/liferay/eslint-config-liferay/pull/68))
+-   feat: add liferay-portal/no-react-dom-render rule ([\#71](https://github.com/liferay/eslint-config-liferay/pull/71))
+-   feat: configure Semantic Pull Requests bot ([\#73](https://github.com/liferay/eslint-config-liferay/pull/73))
+-   fix: repair broken link in no-it-should rule ([\#72](https://github.com/liferay/eslint-config-liferay/pull/72))
+-   docs: provide links to justify rule choices ([\#68](https://github.com/liferay/eslint-config-liferay/pull/68))
 
 ## [v7.0.0](https://github.com/liferay/eslint-config-liferay/tree/v7.0.0) (2019-08-14)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v6.0.0...v7.0.0)
 
-- feat!: activate the "radix" rule ([\#66](https://github.com/liferay/eslint-config-liferay/pull/66))
+-   feat!: activate the "radix" rule ([\#66](https://github.com/liferay/eslint-config-liferay/pull/66))
 
 ## [v6.0.0](https://github.com/liferay/eslint-config-liferay/tree/v6.0.0) (2019-08-12)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v5.0.0...v6.0.0)
 
-- chore: fixes sorting of keys ([\#64](https://github.com/liferay/eslint-config-liferay/pull/64))
-- feat!: enables sort-keys rule to make sure keys are sorted alphabetically in ascending order ([\#63](https://github.com/liferay/eslint-config-liferay/pull/63))
-- feat: adds no-global-fetch rule to avoid direct usage of fetch in favour of our thin wrapper ([\#62](https://github.com/liferay/eslint-config-liferay/pull/62))
-- feat: adds no-metal-plugins rule to avoid deprecated metal-* imports ([\#61](https://github.com/liferay/eslint-config-liferay/pull/61))
-- doc: remove unnecessary blank line from CONTRIBUTING.md ([\#60](https://github.com/liferay/eslint-config-liferay/pull/60))
+-   chore: fixes sorting of keys ([\#64](https://github.com/liferay/eslint-config-liferay/pull/64))
+-   feat!: enables sort-keys rule to make sure keys are sorted alphabetically in ascending order ([\#63](https://github.com/liferay/eslint-config-liferay/pull/63))
+-   feat: adds no-global-fetch rule to avoid direct usage of fetch in favour of our thin wrapper ([\#62](https://github.com/liferay/eslint-config-liferay/pull/62))
+-   feat: adds no-metal-plugins rule to avoid deprecated metal-\* imports ([\#61](https://github.com/liferay/eslint-config-liferay/pull/61))
+-   doc: remove unnecessary blank line from CONTRIBUTING.md ([\#60](https://github.com/liferay/eslint-config-liferay/pull/60))
 
 ## [v5.0.0](https://github.com/liferay/eslint-config-liferay/tree/v5.0.0) (2019-08-08)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.6.0...v5.0.0)
 
-- feat!: enforce use of React fragment shorthand syntax ([\#58](https://github.com/liferay/eslint-config-liferay/pull/58))
+-   feat!: enforce use of React fragment shorthand syntax ([\#58](https://github.com/liferay/eslint-config-liferay/pull/58))
 
 ## [v4.6.0](https://github.com/liferay/eslint-config-liferay/tree/v4.6.0) (2019-08-06)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.5.0...v4.6.0)
 
-- chore: update to ESLint v6 ([\#56](https://github.com/liferay/eslint-config-liferay/pull/56))
+-   chore: update to ESLint v6 ([\#56](https://github.com/liferay/eslint-config-liferay/pull/56))
 
 ## [v4.5.0](https://github.com/liferay/eslint-config-liferay/tree/v4.5.0) (2019-07-17)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.4.0...v4.5.0)
 
-- feat: add liferay-portal/no-explicit-extend rule ([\#54](https://github.com/liferay/eslint-config-liferay/pull/54))
-- docs: simplify instructions in README ([\#53](https://github.com/liferay/eslint-config-liferay/pull/53))
+-   feat: add liferay-portal/no-explicit-extend rule ([\#54](https://github.com/liferay/eslint-config-liferay/pull/54))
+-   docs: simplify instructions in README ([\#53](https://github.com/liferay/eslint-config-liferay/pull/53))
 
 ## [v4.4.0](https://github.com/liferay/eslint-config-liferay/tree/v4.4.0) (2019-07-16)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.3.0...v4.4.0)
 
-- style: sort JSX properties ([\#51](https://github.com/liferay/eslint-config-liferay/pull/51))
+-   style: sort JSX properties ([\#51](https://github.com/liferay/eslint-config-liferay/pull/51))
 
 ## [v4.3.0](https://github.com/liferay/eslint-config-liferay/tree/v4.3.0) (2019-07-09)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.2.0...v4.3.0)
 
-- feat: add "liferay/metal" preset ([\#50](https://github.com/liferay/eslint-config-liferay/pull/50))
+-   feat: add "liferay/metal" preset ([\#50](https://github.com/liferay/eslint-config-liferay/pull/50))
 
 ## [v4.2.0](https://github.com/liferay/eslint-config-liferay/tree/v4.2.0) (2019-07-08)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.1.1...v4.2.0)
 
-- feat: make notice/notice plugin work in liferay-portal projects ([\#49](https://github.com/liferay/eslint-config-liferay/pull/49))
+-   feat: make notice/notice plugin work in liferay-portal projects ([\#49](https://github.com/liferay/eslint-config-liferay/pull/49))
 
 ## [v4.1.1](https://github.com/liferay/eslint-config-liferay/tree/v4.1.1) (2019-06-27)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.1.0...v4.1.1)
 
-- fix(no-it-should): anchor "should" pattern to start of string ([\#48](https://github.com/liferay/eslint-config-liferay/pull/48))
-- docs: correct rule name in README.md ([\#47](https://github.com/liferay/eslint-config-liferay/pull/47))
-- docs: add CONTRIBUTING.md ([\#46](https://github.com/liferay/eslint-config-liferay/pull/46))
+-   fix(no-it-should): anchor "should" pattern to start of string ([\#48](https://github.com/liferay/eslint-config-liferay/pull/48))
+-   docs: correct rule name in README.md ([\#47](https://github.com/liferay/eslint-config-liferay/pull/47))
+-   docs: add CONTRIBUTING.md ([\#46](https://github.com/liferay/eslint-config-liferay/pull/46))
 
 ## [v4.1.0](https://github.com/liferay/eslint-config-liferay/tree/v4.1.0) (2019-06-27)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v4.0.0...v4.1.0)
 
-- docs: add a disclaimer about ESLint coverage in liferay-portal ([\#45](https://github.com/liferay/eslint-config-liferay/pull/45))
-- feat: add liferay-portal/no-side-navigation rule ([\#44](https://github.com/liferay/eslint-config-liferay/pull/44))
-- feat: add liferay/no-it-should rule ([\#43](https://github.com/liferay/eslint-config-liferay/pull/43))
+-   docs: add a disclaimer about ESLint coverage in liferay-portal ([\#45](https://github.com/liferay/eslint-config-liferay/pull/45))
+-   feat: add liferay/no-side-navigation rule ([\#44](https://github.com/liferay/eslint-config-liferay/pull/44))
+-   feat: add liferay/no-it-should rule ([\#43](https://github.com/liferay/eslint-config-liferay/pull/43))
 
 ## [v4.0.0](https://github.com/liferay/eslint-config-liferay/tree/v4.0.0) (2019-06-20)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v3.0.0...v4.0.0)
 
-- feat: add "react" variant ([\#42](https://github.com/liferay/eslint-config-liferay/pull/42))
-- chore: remove liferayportal plugin (#40) ([\#41](https://github.com/liferay/eslint-config-liferay/pull/41))
+-   feat: add "react" variant ([\#42](https://github.com/liferay/eslint-config-liferay/pull/42))
+-   chore: remove liferayportal plugin (#40) ([\#41](https://github.com/liferay/eslint-config-liferay/pull/41))
 
 ## [v3.0.0](https://github.com/liferay/eslint-config-liferay/tree/v3.0.0) (2019-03-05)
+
 [Full Changelog](https://github.com/liferay/eslint-config-liferay/compare/v3.0.0-rc.0...v3.0.0)
 
 **Implemented enhancements:**
 
-- Set up Travis CI [\#32](https://github.com/liferay/eslint-config-liferay/issues/32)
+-   Set up Travis CI [\#32](https://github.com/liferay/eslint-config-liferay/issues/32)
 
 **Closed issues:**
 
-- Tweak rules and plug-ins based on experience integrating into other projects [\#33](https://github.com/liferay/eslint-config-liferay/issues/33)
+-   Tweak rules and plug-ins based on experience integrating into other projects [\#33](https://github.com/liferay/eslint-config-liferay/issues/33)
 
 **Merged pull requests:**
 
-- Tweak rules and plug-ins based on experience integrating into other projects \(\#33\) [\#35](https://github.com/liferay/eslint-config-liferay/pull/35) ([wincent](https://github.com/wincent))
-- Set up Travis CI \(\#32\) [\#34](https://github.com/liferay/eslint-config-liferay/pull/34) ([wincent](https://github.com/wincent))
+-   Tweak rules and plug-ins based on experience integrating into other projects \(\#33\) [\#35](https://github.com/liferay/eslint-config-liferay/pull/35) ([wincent](https://github.com/wincent))
+-   Set up Travis CI \(\#32\) [\#34](https://github.com/liferay/eslint-config-liferay/pull/34) ([wincent](https://github.com/wincent))
 
 ## [v3.0.0-rc.0](https://github.com/liferay/eslint-config-liferay/tree/v3.0.0-rc.0) (2019-03-04)
+
 [Full Changelog](https://github.com/liferay/eslint-config-liferay/compare/v2.0.10...v3.0.0-rc.0)
 
 **Implemented enhancements:**
 
-- Replace opaque 0, 1, 2 in config with transparent "off", "warn", "error" [\#23](https://github.com/liferay/eslint-config-liferay/issues/23)
-- Add no-only-tests plug-in and rule [\#20](https://github.com/liferay/eslint-config-liferay/issues/20)
-- Add no-unused-expressions rule to the default set [\#19](https://github.com/liferay/eslint-config-liferay/issues/19)
-- Use Prettier [\#16](https://github.com/liferay/eslint-config-liferay/issues/16)
-- Use eslint-config-liferay to lint itself [\#13](https://github.com/liferay/eslint-config-liferay/issues/13)
-- Switch to Yarn [\#11](https://github.com/liferay/eslint-config-liferay/issues/11)
+-   Replace opaque 0, 1, 2 in config with transparent "off", "warn", "error" [\#23](https://github.com/liferay/eslint-config-liferay/issues/23)
+-   Add no-only-tests plug-in and rule [\#20](https://github.com/liferay/eslint-config-liferay/issues/20)
+-   Add no-unused-expressions rule to the default set [\#19](https://github.com/liferay/eslint-config-liferay/issues/19)
+-   Use Prettier [\#16](https://github.com/liferay/eslint-config-liferay/issues/16)
+-   Use eslint-config-liferay to lint itself [\#13](https://github.com/liferay/eslint-config-liferay/issues/13)
+-   Switch to Yarn [\#11](https://github.com/liferay/eslint-config-liferay/issues/11)
 
 **Fixed bugs:**
 
-- Fix pre-existing lints inside eslint-config-liferay [\#27](https://github.com/liferay/eslint-config-liferay/issues/27)
-- Don't autocreate .eslintrc when .eslintrc.js already exists [\#10](https://github.com/liferay/eslint-config-liferay/issues/10)
+-   Fix pre-existing lints inside eslint-config-liferay [\#27](https://github.com/liferay/eslint-config-liferay/issues/27)
+-   Don't autocreate .eslintrc when .eslintrc.js already exists [\#10](https://github.com/liferay/eslint-config-liferay/issues/10)
 
 **Closed issues:**
 
-- Sync with latest changes from liferay/clay [\#25](https://github.com/liferay/eslint-config-liferay/issues/25)
-- Evaluate continued use of eslint-config-google [\#18](https://github.com/liferay/eslint-config-liferay/issues/18)
-- Add missing license headers to files [\#17](https://github.com/liferay/eslint-config-liferay/issues/17)
-- Remove outdated .editorconfig [\#14](https://github.com/liferay/eslint-config-liferay/issues/14)
-- Update ESLint dependency [\#12](https://github.com/liferay/eslint-config-liferay/issues/12)
-- Move this repo to liferay org [\#9](https://github.com/liferay/eslint-config-liferay/issues/9)
+-   Sync with latest changes from liferay/clay [\#25](https://github.com/liferay/eslint-config-liferay/issues/25)
+-   Evaluate continued use of eslint-config-google [\#18](https://github.com/liferay/eslint-config-liferay/issues/18)
+-   Add missing license headers to files [\#17](https://github.com/liferay/eslint-config-liferay/issues/17)
+-   Remove outdated .editorconfig [\#14](https://github.com/liferay/eslint-config-liferay/issues/14)
+-   Update ESLint dependency [\#12](https://github.com/liferay/eslint-config-liferay/issues/12)
+-   Move this repo to liferay org [\#9](https://github.com/liferay/eslint-config-liferay/issues/9)
 
 **Merged pull requests:**
 
-- v3.0.0-rc.0 [\#31](https://github.com/liferay/eslint-config-liferay/pull/31) ([wincent](https://github.com/wincent))
--  Sync with latest changes from liferay/clay \(\#25\) [\#30](https://github.com/liferay/eslint-config-liferay/pull/30) ([wincent](https://github.com/wincent))
-- Fix pre-existing lints inside eslint-config-liferay [\#29](https://github.com/liferay/eslint-config-liferay/pull/29) ([wincent](https://github.com/wincent))
-- Document how to use "copyright.js" [\#28](https://github.com/liferay/eslint-config-liferay/pull/28) ([wincent](https://github.com/wincent))
-- Add missing license headers to files \(\#17\) [\#26](https://github.com/liferay/eslint-config-liferay/pull/26) ([wincent](https://github.com/wincent))
-- Address some other initial issues [\#24](https://github.com/liferay/eslint-config-liferay/pull/24) ([wincent](https://github.com/wincent))
-- Add no-only-tests plug-in and rule \(\#20\) [\#22](https://github.com/liferay/eslint-config-liferay/pull/22) ([wincent](https://github.com/wincent))
-- Resolve initial set of issues [\#15](https://github.com/liferay/eslint-config-liferay/pull/15) ([wincent](https://github.com/wincent))
+-   v3.0.0-rc.0 [\#31](https://github.com/liferay/eslint-config-liferay/pull/31) ([wincent](https://github.com/wincent))
+-   Sync with latest changes from liferay/clay \(\#25\) [\#30](https://github.com/liferay/eslint-config-liferay/pull/30) ([wincent](https://github.com/wincent))
+-   Fix pre-existing lints inside eslint-config-liferay [\#29](https://github.com/liferay/eslint-config-liferay/pull/29) ([wincent](https://github.com/wincent))
+-   Document how to use "copyright.js" [\#28](https://github.com/liferay/eslint-config-liferay/pull/28) ([wincent](https://github.com/wincent))
+-   Add missing license headers to files \(\#17\) [\#26](https://github.com/liferay/eslint-config-liferay/pull/26) ([wincent](https://github.com/wincent))
+-   Address some other initial issues [\#24](https://github.com/liferay/eslint-config-liferay/pull/24) ([wincent](https://github.com/wincent))
+-   Add no-only-tests plug-in and rule \(\#20\) [\#22](https://github.com/liferay/eslint-config-liferay/pull/22) ([wincent](https://github.com/wincent))
+-   Resolve initial set of issues [\#15](https://github.com/liferay/eslint-config-liferay/pull/15) ([wincent](https://github.com/wincent))
 
 ## [v2.0.10](https://github.com/liferay/eslint-config-liferay/tree/v2.0.10) (2017-11-15)
+
 [Full Changelog](https://github.com/liferay/eslint-config-liferay/compare/v1.0.2...v2.0.10)
 
 **Closed issues:**
 
-- What are the benefits of allowing unused function params? [\#5](https://github.com/liferay/eslint-config-liferay/issues/5)
-- Enforce indentation? [\#4](https://github.com/liferay/eslint-config-liferay/issues/4)
+-   What are the benefits of allowing unused function params? [\#5](https://github.com/liferay/eslint-config-liferay/issues/5)
+-   Enforce indentation? [\#4](https://github.com/liferay/eslint-config-liferay/issues/4)
 
 **Merged pull requests:**
 
-- cwd is located in the dependency during the execution of postinstall script [\#8](https://github.com/liferay/eslint-config-liferay/pull/8) ([robframpton](https://github.com/robframpton))
-- Make post install script compatible with older versions of Node [\#7](https://github.com/liferay/eslint-config-liferay/pull/7) ([robframpton](https://github.com/robframpton))
-- Prevents unused arguments after the last used one [\#6](https://github.com/liferay/eslint-config-liferay/pull/6) ([jbalsas](https://github.com/jbalsas))
+-   cwd is located in the dependency during the execution of postinstall script [\#8](https://github.com/liferay/eslint-config-liferay/pull/8) ([robframpton](https://github.com/robframpton))
+-   Make post install script compatible with older versions of Node [\#7](https://github.com/liferay/eslint-config-liferay/pull/7) ([robframpton](https://github.com/robframpton))
+-   Prevents unused arguments after the last used one [\#6](https://github.com/liferay/eslint-config-liferay/pull/6) ([jbalsas](https://github.com/jbalsas))
 
 ## [v1.0.2](https://github.com/liferay/eslint-config-liferay/tree/v1.0.2) (2017-06-09)
+
 [Full Changelog](https://github.com/liferay/eslint-config-liferay/compare/v1.0.1...v1.0.2)
 
 ## [v1.0.1](https://github.com/liferay/eslint-config-liferay/tree/v1.0.1) (2017-04-20)
+
 **Merged pull requests:**
 
-- Adds eslint-config-google as distribution dependency [\#2](https://github.com/liferay/eslint-config-liferay/pull/2) ([pragmaticivan](https://github.com/pragmaticivan))
-- Updates default rules based on compatibility with current projects and prettier configuration [\#1](https://github.com/liferay/eslint-config-liferay/pull/1) ([pragmaticivan](https://github.com/pragmaticivan))
+-   Adds eslint-config-google as distribution dependency [\#2](https://github.com/liferay/eslint-config-liferay/pull/2) ([pragmaticivan](https://github.com/pragmaticivan))
+-   Updates default rules based on compatibility with current projects and prettier configuration [\#1](https://github.com/liferay/eslint-config-liferay/pull/1) ([pragmaticivan](https://github.com/pragmaticivan))


### PR DESCRIPTION
Because I forgot to update it for the v11.1.0 release.

Done with:

    npx liferay-changelog-generator --regenerate --version v11.1.1

But I kept the very old parts (pre-v4.0.0) because those date back to the github_changelog_generator days, and just ran Prettier over everything.