### PR TITLE
fix(sort-imports): make sure "metal" sorts before "metal-dom"

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/rules/sort-imports.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-imports.js
@@ -18,24 +18,23 @@ const {
 const DESCRIPTION = 'imports must be sorted';
 
 /**
- * Given two source strings `a` and `b`, return -1, 0 or 1 to indicate
+ * Given two sort keys `a` and `b`, return -1, 0 or 1 to indicate
  * their relative ordering.
  */
-function compare(a, b) {
-	const compareBy = fn => {
-		const [rankA, rankB] = [fn(a), fn(b)];
+function compare(aKey, bKey) {
+	const [aName, aTieBreaker] = aKey.split(':');
+	const [bName, bTieBreaker] = bKey.split(':');
 
-		return rankA < rankB ? -1 : rankA > rankB ? 1 : 0;
+	const cmp = (a, b) => {
+		return a < b ? -1 : a > b ? 1 : 0;
 	};
 
-	const result = compareBy(ranking);
-
-	if (result) {
-		return result;
-	}
-
-	// Break ties with a standard lexicographical (case-sensitive) sort.
-	return compareBy(name => name);
+	//
+	return (
+		cmp(ranking(aName), ranking(bName)) ||
+		cmp(aName, bName) ||
+		cmp(aTieBreaker, bTieBreaker)
+	);
 }
 
 /**

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
@@ -254,6 +254,25 @@ ruleTester.run('sort-imports', rule, {
 				const path = require('path');
 			`,
 		},
+		{
+			// Regression test: "metal-dom" was sorting before "metal".
+			code: `
+				import dom from 'metal-dom';
+				import core from 'metal';
+			`,
+			errors: [
+				{
+					message:
+						'imports must be sorted by module name ' +
+						'(expected: "metal" << "metal-dom")',
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `
+				import core from 'metal';
+				import dom from 'metal-dom';
+			`,
+		},
 	],
 
 	valid: [


### PR DESCRIPTION
We had a bug in here due to some special casing for the pathological scenario in which you have multiple imports from the same module. In that case, we need to break ties, so we created a sort key of the form "module-name:tie-breaker" and compared that.

For something like these two imports...

    import dom from 'metal-dom';
    import core from 'metal';

we'd make two sort keys, "metal-dom:dom" and "metal:core", and unfortunately, "-" sorts before ":", giving us the wrong result.

So, the fix is to only use the tie-breaker if the names are the same.

Closes: #111