### PR TITLE
fix!: make it possible to override copyright template file (#115)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+const path = require('path');
+
 module.exports = {
 	env: {
 		// Available environments: https://eslint.org/docs/user-guide/configuring#specifying-environments
@@ -24,5 +26,12 @@ module.exports = {
 	parserOptions: {
 		ecmaVersion: 2018,
 	},
-	rules: {},
+	rules: {
+		'notice/notice': [
+			'error',
+			{
+				templateFile: path.join(__dirname, 'copyright.js'),
+			},
+		],
+	},
 };

--- a/README.md
+++ b/README.md
@@ -52,7 +52,36 @@ This extension is applied automatically by [liferay-npm-scripts](https://github.
 
 ### Copyright headers
 
-The included [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugin-notice) plug-in can be used to enforce the use of uniform copyright headers across a project by placing a template named `copyright.js` in the project root (for example, see [the file defining the headers used in eslint-config-liferay itself](https://github.com/liferay/eslint-config-liferay/blob/master/copyright.js)).
+The included [`eslint-plugin-notice`](https://www.npmjs.com/package/eslint-plugin-notice) plug-in can be used to enforce the use of uniform copyright headers across a project by placing a template named `copyright.js` in the project root (for example, see [the file defining the headers used in eslint-config-liferay itself](https://github.com/liferay/eslint-config-liferay/blob/master/copyright.js)) and configuring the rule:
+
+```javascript
+const path = require('path');
+
+module.exports = {
+	extends: ['liferay'],
+	rules: {
+		'notice/notice': [
+			'error',
+			{
+				templateFile: path.join(__dirname, 'copyright.js'),
+			},
+		],
+	},
+};
+```
+
+Explicit configuration is required in order to make overrides possible; for example:
+
+-   `top-level/`
+    -   `.eslintrc.js`
+    -   `copyright.js`
+    -   `mid-level/`
+        -   `.eslintrc.js`
+        -   `copyright.js`
+        -   `bottom-level/`
+            -   `.eslintrc.js`
+
+If we were to provide configuration by default, then if `bottom-level/.eslintrc.js` does an `extends: ['liferay']`, then the default configuration would be considered more local than the one provided by `mid-level`, causing the wrong `copyright.js` to be used.
 
 ### Base rules
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@
 
 'use strict';
 
-const fs = require('fs');
-
 const local = require('./utils/local');
 
 const config = {
@@ -59,14 +57,5 @@ const config = {
 		'sort-keys': ['error', 'asc', {caseSensitive: true, natural: true}],
 	},
 };
-
-if (fs.existsSync('copyright.js')) {
-	config.rules['notice/notice'] = [
-		'error',
-		{
-			templateFile: 'copyright.js',
-		},
-	];
-}
 
 module.exports = config;

--- a/portal.js
+++ b/portal.js
@@ -6,9 +6,6 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
 const local = require('./utils/local');
 
 const config = {
@@ -28,24 +25,5 @@ const config = {
 		'no-restricted-globals': ['error', 'event'],
 	},
 };
-
-/**
- * The standard configuration (in "./index") only looks for a template
- * in the current working directory; here we make things work when run from a
- * project directory of the form "modules/apps/foo/bar" in the liferay-portal
- * repo.
- */
-if (
-	path.basename(process.cwd()) !== 'modules' &&
-	path.basename(path.resolve('../../..')) === 'modules' &&
-	fs.existsSync('../../../copyright.js')
-) {
-	config.rules['notice/notice'] = [
-		'error',
-		{
-			templateFile: '../../../copyright.js',
-		},
-	];
-}
 
 module.exports = config;


### PR DESCRIPTION
Sadly, this is a breaking change, and will require projects using eslint-config-liferay to update their config.

Closes: https://github.com/liferay/eslint-config-liferay/issues/115