### PR TITLE
feat!: teach no-explicit-extend to complain about liferay/react too

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plug
 The bundled `eslint-plugin-liferay-portal` plugin includes the following [rules](./plugins/eslint-plugin-liferay-portal/docs/rules):
 
 -   [liferay-portal/no-global-fetch](./plugins/eslint-plugin-liferay-portal/docs/rules/no-global-fetch.md): Prevents usage of unwrapped fetch to avoid possible issues related to security misconfiguration.
--   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary `extends: ["liferay/portal"]` configuration.
+-   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary `extends: ["liferay/portal"]` or `extends: ["liferay/react"]` configuration.
 -   [liferay-portal/no-metal-plugins](./plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md): Prevents usage of deprecated `metal-*` plugins and utilities.
 -   [liferay-portal/no-react-dom-render](./plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md): Prevents direct usage of `ReactDOM.render` in favor of our wrapper.
 -   [liferay-portal/no-side-navigation](./plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
@@ -1,6 +1,6 @@
-# Disallow unnecessary `extends: ["liferay/portal"]` configuration (no-explicit-extends)
+# Disallow unnecessary `extends: ["liferay/portal", "liferay/react"]` configuration (no-explicit-extends)
 
-This rule guards against unnecessary inclusion of the "liferay/portal" configuration.
+This rule guards against unnecessary inclusion of the "liferay/portal" or "liferay/react" configurations.
 
 ## Rule Details
 
@@ -9,7 +9,7 @@ Examples of **incorrect** code for this rule:
 ```js
 // .eslintrc.js
 module.exports = {
-	extends: ['liferay/portal', 'liferay/react'],
+	extends: ['liferay/metal', 'liferay/portal', 'liferay/react'],
 };
 ```
 
@@ -18,10 +18,11 @@ Examples of **correct** code for this rule:
 ```js
 // .eslintrc.js
 module.exports = {
-	extends: ['liferay/react'],
+	extends: ['liferay/metal'],
 };
 ```
 
 ## Further Reading
 
 -   [eslint-config-liferay/#53](https://github.com/liferay/eslint-config-liferay/pull/53)
+-   [IFI-1194](https://issues.liferay.com/browse/IFI-1194)

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -15,7 +15,7 @@ const filename = '/data/liferay-portal/modules/apps/a/b/.eslintrc.js';
 ruleTester.run('no-explicit-extend', rule, {
 	invalid: [
 		{
-			// As a naked string.
+			// As a naked string (liferay/portal).
 			code: `
 				module.exports = {
 					extends: 'liferay/portal'
@@ -24,7 +24,25 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {};
+			`,
+		},
+		{
+			// As a naked string (liferay/react).
+			code: `
+				module.exports = {
+					extends: 'liferay/react'
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -43,7 +61,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -65,7 +83,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -87,7 +105,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -101,19 +119,19 @@ ruleTester.run('no-explicit-extend', rule, {
 			// At the beginning, on one line.
 			code: `
 				module.exports = {
-					extends: ['liferay/portal', 'liferay/react']
+					extends: ['liferay/portal', 'other']
 				};
 			`,
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'ArrayExpression',
 				},
 			],
 			filename,
 			output: `
 				module.exports = {
-					extends: ['liferay/react']
+					extends: ['other']
 				};
 			`,
 		},
@@ -121,19 +139,19 @@ ruleTester.run('no-explicit-extend', rule, {
 			// In the middle, on one line.
 			code: `
 				module.exports = {
-					extends: ['special', 'liferay/portal', 'liferay/react']
+					extends: ['special', 'liferay/portal', 'other']
 				};
 			`,
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'ArrayExpression',
 				},
 			],
 			filename,
 			output: `
 				module.exports = {
-					extends: ['special', 'liferay/react']
+					extends: ['special', 'other']
 				};
 			`,
 		},
@@ -141,19 +159,116 @@ ruleTester.run('no-explicit-extend', rule, {
 			// At the end, on one line.
 			code: `
 				module.exports = {
-					extends: ['liferay/react', 'liferay/portal']
+					extends: ['something', 'liferay/portal']
 				};
 			`,
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'ArrayExpression',
 				},
 			],
 			filename,
 			output: `
 				module.exports = {
-					extends: ['liferay/react']
+					extends: ['something']
+				};
+			`,
+		},
+		{
+			// Both liferay/portal and liferay/react together (at start).
+			code: `
+				module.exports = {
+					extends: [
+						'liferay/portal',
+						'liferay/react',
+						'trailing'
+					]
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'ArrayExpression',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: [
+						'trailing'
+					]
+				};
+			`,
+		},
+		{
+			// Both liferay/portal and liferay/react together (at end).
+			code: `
+				module.exports = {
+					extends: ['foo', 'liferay/portal', 'liferay/react']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'ArrayExpression',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: ['foo']
+				};
+			`,
+		},
+		{
+			// Both liferay/portal and liferay/react together (in the middle).
+			code: `
+				module.exports = {
+					extends: ['foo', 'liferay/portal', 'liferay/react', 'bar']
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'ArrayExpression',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: ['foo', 'bar']
+				};
+			`,
+		},
+		{
+			// Both liferay/portal and liferay/react together (with something in
+			// between).
+			code: `
+				module.exports = {
+					extends: [
+						'foo',
+						'liferay/portal',
+						'bar',
+						'liferay/react',
+						'baz'
+					]
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'ArrayExpression',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					extends: [
+						'foo',
+						'bar',
+						'baz'
+					]
 				};
 			`,
 		},
@@ -167,7 +282,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -185,7 +300,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -205,7 +320,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			errors: [
 				{
 					messageId: 'noExplicitExtend',
-					type: 'Literal',
+					type: 'Property',
 				},
 			],
 			filename,
@@ -219,7 +334,7 @@ ruleTester.run('no-explicit-extend', rule, {
 		{
 			code: `
 				module.exports = {
-					extends: ['liferay/react']
+					extends: ['liferay/metal']
 				};
 			`,
 			filename,
@@ -227,7 +342,7 @@ ruleTester.run('no-explicit-extend', rule, {
 		{
 			code: `
 				module.exports = {
-					extends: 'liferay/react'
+					extends: 'liferay/metal'
 				};
 			`,
 			filename,
@@ -248,6 +363,22 @@ ruleTester.run('no-explicit-extend', rule, {
 				};
 			`,
 			filename: '/tmp/not-an-eslintrc.js',
+		},
+		{
+			// Nod invalid, but not under an "extends" property.
+			code: `
+				module.exports = {
+					extendz: 'liferay/portal'
+				};
+			`,
+			filename,
+		},
+		{
+			// Not invalid, because not in an object.
+			code: `
+				var array = ['liferay/portal'];
+			`,
+			filename,
 		},
 	],
 });

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -365,7 +365,7 @@ ruleTester.run('no-explicit-extend', rule, {
 			filename: '/tmp/not-an-eslintrc.js',
 		},
 		{
-			// Nod invalid, but not under an "extends" property.
+			// Not invalid, but not under an "extends" property.
 			code: `
 				module.exports = {
 					extendz: 'liferay/portal'


### PR DESCRIPTION
Previously this rule prevented the use of the explicit use of "liferay/portal" inside liferay-portal, because it is the default.

As of https://issues.liferay.com/browse/IFI-1194, "liferay/react" is effectively a default as well (because we made "liferay/portal" extend "liferay/react").

Nevertheless, some redundant config has snuck into liferay-portal recently, and I cleaned that up here:

https://github.com/brianchandotcom/liferay-portal/pull/83195

This commit updates our no-explicit-extend rule to prevent this from happening again by adding "liferay/react" to the list of disallowed explicit presets. Note that it required fairly significant changes to the rule because the old rule wasn't made with multiple defaults in mind; as such, I added quite a few test cases to increase my confidence that I hadn't broken anything.