### PR TITLE
feat!: lint against use of redundant presets in .babelrc.js files (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The bundled `eslint-plugin-liferay` plugin includes the following [rules](./plug
 The bundled `eslint-plugin-liferay-portal` plugin includes the following [rules](./plugins/eslint-plugin-liferay-portal/docs/rules):
 
 -   [liferay-portal/no-global-fetch](./plugins/eslint-plugin-liferay-portal/docs/rules/no-global-fetch.md): Prevents usage of unwrapped fetch to avoid possible issues related to security misconfiguration.
--   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary `extends: ["liferay/portal"]` or `extends: ["liferay/react"]` configuration.
+-   [liferay-portal/no-explicit-extend](./plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md): Prevents unnecessary extensions in ESLint and Babel configuration files.
 -   [liferay-portal/no-metal-plugins](./plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md): Prevents usage of deprecated `metal-*` plugins and utilities.
 -   [liferay-portal/no-react-dom-render](./plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md): Prevents direct usage of `ReactDOM.render` in favor of our wrapper.
 -   [liferay-portal/no-side-navigation](./plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md): Guards against the use of the legacy jQuery `sideNavigation` plugin.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
@@ -1,6 +1,10 @@
-# Disallow unnecessary `extends: ["liferay/portal", "liferay/react"]` configuration (no-explicit-extends)
+# Disallow unnecessary extensions in configuration files (no-explicit-extends)
 
-This rule guards against unnecessary inclusion of the "liferay/portal" or "liferay/react" configurations.
+This rule guards against unnecessary extensions in configuration files.
+
+For example, in `.eslintrc.js` files, it is not necessary to include the "liferay/portal" or "liferay/react" configurations in the "extends" property, because these apply by default in liferay-portal.
+
+Likewise, in `.babelrc.js` files, it is not necessary to include "@babel/preset-env" or "@babel/preset-react" in the "presets" property, because they also apply by default.
 
 ## Rule Details
 
@@ -11,6 +15,11 @@ Examples of **incorrect** code for this rule:
 module.exports = {
 	extends: ['liferay/metal', 'liferay/portal', 'liferay/react'],
 };
+
+// .babelrc.js
+modlue.exports = {
+	presets: ['@babel/preset-env', '@babel/preset-react', 'fancy-preset'],
+};
 ```
 
 Examples of **correct** code for this rule:
@@ -20,9 +29,15 @@ Examples of **correct** code for this rule:
 module.exports = {
 	extends: ['liferay/metal'],
 };
+
+// .babelrc.js
+modlue.exports = {
+	presets: ['fancy-preset'],
+};
 ```
 
 ## Further Reading
 
 -   [eslint-config-liferay/#53](https://github.com/liferay/eslint-config-liferay/pull/53)
+-   [eslint-config-liferay/#130](https://github.com/liferay/eslint-config-liferay/issues/130)
 -   [IFI-1194](https://issues.liferay.com/browse/IFI-1194)

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
@@ -17,7 +17,7 @@ module.exports = {
 };
 
 // .babelrc.js
-modlue.exports = {
+module.exports = {
 	presets: ['@babel/preset-env', '@babel/preset-react', 'fancy-preset'],
 };
 ```
@@ -31,7 +31,7 @@ module.exports = {
 };
 
 // .babelrc.js
-modlue.exports = {
+module.exports = {
 	presets: ['fancy-preset'],
 };
 ```

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -328,6 +328,42 @@ ruleTester.run('no-explicit-extend', rule, {
 				module.exports = {};
 			`,
 		},
+		{
+			// In a .babelrc.js file.
+			code: `
+				module.exports = {
+					presets: [
+						'fancy-preset',
+						'@babel/preset-env',
+					],
+					overrides: [{
+						test: 'some/path',
+						presets: ['@babel/preset-react'],
+					}]
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitPreset',
+					type: 'ArrayExpression',
+				},
+				{
+					messageId: 'noExplicitPreset',
+					type: 'Property',
+				},
+			],
+			filename: '.babelrc.js',
+			output: `
+				module.exports = {
+					presets: [
+						'fancy-preset',
+					],
+					overrides: [{
+						test: 'some/path',
+					}]
+				};
+			`,
+		},
 	],
 
 	valid: [
@@ -379,6 +415,15 @@ ruleTester.run('no-explicit-extend', rule, {
 				var array = ['liferay/portal'];
 			`,
 			filename,
+		},
+		{
+			// Would be invalid, but not in a .babelrc.js file.
+			code: `
+				module.exports = {
+					presets: ['@babel/preset-react']
+				};
+			`,
+			filename: '/tmp/not-a-babelrc.js',
 		},
 	],
 });


### PR DESCRIPTION
Related:

- https://github.com/liferay/liferay-npm-tools/pull/340: teaches liferay-npm-scripts to force the use of ".babelrc.js" so that we can check it with this rule.
- https://github.com/liferay/liferay-npm-tools/pull/335: makes "@babel/preset-react" apply by default ("@babel/preset-env" already did apply by default).
- https://github.com/wincent/liferay-portal/pull/120: PR showing that changing the default works in liferay-portal; before sending that I will send an update that moves all the remaining ".babelrc" to ".babelrc.js" (there are surprisingly few of them).

Closes: https://github.com/liferay/eslint-config-liferay/issues/130