### PR TITLE
fix: make sort-import-destructures work with long lists

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
@@ -29,8 +29,6 @@ module.exports = {
 						return;
 					}
 
-					let fix;
-
 					// Given:
 					//
 					//      import {a as b, c} from 'd';
@@ -42,15 +40,12 @@ module.exports = {
 					//
 					// We sort by `imported` always, ignoring `local`.
 					const sorted = specifiers.slice().sort((a, b) => {
-						const order =
-							a.imported.name > b.imported.name ? 1 : -1;
-
-						if (order === 1) {
-							fix = true;
-						}
-
-						return order;
+						return a.imported.name > b.imported.name ? 1 : -1;
 					});
+
+					const fix = sorted.some(
+						(sorted, i) => sorted !== specifiers[i]
+					);
 
 					if (fix) {
 						const text =

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
@@ -129,5 +129,23 @@ ruleTester.run('sort-import-destructures', rule, {
 				} from 'numbers';
 			`,
 		},
+		{
+			// Regression test. This was being incorrectly flagged as unsorted.
+			code: `
+				import {
+					addFragmentEntryLinkReducer,
+					deleteFragmentEntryLinkCommentReducer,
+					duplicateFragmentEntryLinkReducer,
+					moveFragmentEntryLinkReducer,
+					removeFragmentEntryLinkReducer,
+					toggleShowResolvedCommentsReducer,
+					updateEditableValueReducer,
+					updateFragmentEntryKeysReducer,
+					updateFragmentEntryLinkCommentReducer,
+					updateFragmentEntryLinkConfigReducer,
+					updateFragmentEntryLinkContentReducer
+				} from './fragments.es';
+			`,
+		},
 	],
 });


### PR DESCRIPTION
The old implementation happened to work with short lists but it made too many assumptions about the order in which pairs in the list would be compared. As soon as we tried running this on files with many names being destructured (like the one in the included regression test), then the assumption (that we'd only ever call element in list-order) was invalidated.

V8 actually uses Timsort under the covers (https://v8.dev/blog/array-sort), but that is besides the point. We need to make sure the comparator function passed to `sort` behaves identically regardless of comparison order.