### PR TITLE
fix(meta): make globs work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
 	},
 	"scripts": {
 		"ci": "yarn lint && yarn format:check && yarn test",
-		"format": "prettier --write -- '**/*.{js,json,md}' '.*.js'",
-		"format:check": "prettier --list-different -- '**/*.{js,json,md}' '.*.js'",
+		"format": "prettier --write -- \"**/*.{js,json,md}\" \".*.js\"",
+		"format:check": "prettier --list-different -- \"**/*.{js,json,md}\" \".*.js\"",
 		"lint": "node scripts/lint.js",
 		"lint:fix": "node scripts/lint.js --fix",
 		"postinstall": "node scripts/postinstall.js",


### PR DESCRIPTION
Analogous change to this one on the alloy-editor repo:

https://github.com/liferay/alloy-editor/pull/1374

Just in case anybody is ever foolhardy enough to try doing development on this repo on Windows.