### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /.eslintrc-internal.js
+/copyright.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Liferay, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/metal.js
+++ b/metal.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/index.js
+++ b/plugins/eslint-plugin-liferay-portal/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-global-fetch.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-global-fetch.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-loader-import-specifier.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-loader-import-specifier.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-metal-plugins.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-react-dom-render.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-react-dom-render.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-side-navigation.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-side-navigation.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-global-fetch.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-global-fetch.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-loader-import-specifier.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-loader-import-specifier.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/index.js
+++ b/plugins/eslint-plugin-liferay/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/common/className.js
+++ b/plugins/eslint-plugin-liferay/lib/common/className.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/common/imports.js
+++ b/plugins/eslint-plugin-liferay/lib/common/imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/array-is-array.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/array-is-array.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/destructure-requires.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/destructure-requires.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/group-imports.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/group-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/import-extensions.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/import-extensions.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/imports-first.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/imports-first.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-absolute-import.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-absolute-import.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-duplicate-class-names.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-duplicate-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-duplicate-imports.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-duplicate-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-dynamic-require.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-dynamic-require.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-it-should.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/no-require-and-call.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/no-require-and-call.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/padded-test-blocks.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/padded-test-blocks.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/sort-class-names.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/sort-imports.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/lib/rules/trim-class-names.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/trim-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/array-is-array.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/array-is-array.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/destructure-requires.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/destructure-requires.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-absolute-import.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-absolute-import.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-dynamic-require.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-dynamic-require.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-require-and-call.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-require-and-call.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/padded-test-blocks.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/padded-test-blocks.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/trim-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/trim-class-names.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/portal.js
+++ b/portal.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/react.js
+++ b/react.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 

--- a/utils/local.js
+++ b/utils/local.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: MIT
  */
 


### PR DESCRIPTION
Specifically, we need to tweak our copyright header format. I updated the copyright.js template and applied it everywhere (with `yarn lint:fix`). I then used a Vim macro to remove the old headers.

One difference to note: previously we used a hard-coded year, but from now on we should switch to year-of-creation, so in the template I switched to using a `<%= YEAR %>` placeholder. Existing files preserve the original year (2017) but any new files we add will use the current year (ie. if I create a file today, the year will be 2020).

Finally, we add a copy of the license to `LICENSES/MIT.txt`.

See: https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Related: https://issues.liferay.com/browse/FOSS-38