### PR TITLE
fix: don't break when using @typescript-eslint/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
 	"author": "Liferay",
 	"license": "MIT",
 	"devDependencies": {
+		"@typescript-eslint/parser": "^2.20.0",
 		"eslint": "6.8.0",
 		"jest": "25.1.0",
-		"prettier": "*"
+		"prettier": "*",
+		"typescript": "^3.8.2"
 	},
 	"peerDependencies": {
 		"eslint": ">=4.1.1"

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-explicit-extend');
 
-const ruleTester = new RuleTester();
+const ruleTester = new MultiTester();
 
 const filename = '/data/liferay-portal/modules/apps/a/b/.eslintrc.js';
 

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-global-fetch.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-global-fetch.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-global-fetch');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('no-global-fetch', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-loader-import-specifier.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-loader-import-specifier.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-loader-import-specifier');
 
 const parserOptions = {
@@ -12,7 +11,7 @@ const parserOptions = {
 	sourceType: 'module',
 };
 
-const ruleTester = new RuleTester({parserOptions});
+const ruleTester = new MultiTester({parserOptions});
 
 const errors = [
 	{

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-metal-plugins.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-metal-plugins');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('no-metal-plugins', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-react-dom-render.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-react-dom-render');
 
 const parserOptions = {
@@ -15,7 +14,7 @@ const parserOptions = {
 	sourceType: 'module',
 };
 
-const ruleTester = new RuleTester({parserOptions});
+const ruleTester = new MultiTester({parserOptions});
 
 const errors = [
 	{

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-side-navigation.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-side-navigation');
 
 const parserOptions = {
@@ -13,7 +12,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester({parserOptions});
+const ruleTester = new MultiTester({parserOptions});
 
 ruleTester.run('no-side-navigation', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/sort-import-destructures.js
@@ -48,10 +48,10 @@ module.exports = {
 
 					if (fix) {
 						const text =
-							' '.repeat(node.start) + source.getText(node);
+							' '.repeat(node.range[0]) + source.getText(node);
 
-						const start = specifiers[0].start;
-						const end = specifiers[specifiers.length - 1].end;
+						const start = specifiers[0].range[0];
+						const end = specifiers[specifiers.length - 1].range[1];
 
 						let fixed = '';
 
@@ -61,8 +61,8 @@ module.exports = {
 							if (i < specifiers.length - 1) {
 								// Grab all text between specifier and next.
 								const between = text.slice(
-									specifiers[i].end,
-									specifiers[i + 1].start
+									specifiers[i].range[1],
+									specifiers[i + 1].range[0]
 								);
 
 								fixed += between;

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/array-is-array.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/array-is-array.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/array-is-array');
 
 const parserOptions = {
@@ -13,7 +12,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('array-is-array', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/destructure-requires.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/destructure-requires.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/destructure-requires');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('destructure-requires', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/group-imports');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('group-imports', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/import-extensions');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const message = 'unnecessary extension in import';
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/imports-first.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/imports-first');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('imports-first', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-absolute-import.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-absolute-import.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-absolute-import');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('no-absolute-import', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-class-names.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-duplicate-class-names');
 
 const parserOptions = {
@@ -17,7 +16,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const message = 'classes in className attribute must be unique';
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-duplicate-imports.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-duplicate-imports');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('no-duplicate-imports', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-dynamic-require.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-dynamic-require.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-dynamic-require');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('no-dynamic-require', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-it-should.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-it-should');
 
-const ruleTester = new RuleTester();
+const ruleTester = new MultiTester();
 
 ruleTester.run('no-it-should', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/no-require-and-call.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/no-require-and-call.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/no-require-and-call');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const message =
 	'functions returned by require() should be assigned to a variable before calling';

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/padded-test-blocks.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/padded-test-blocks.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/padded-test-blocks');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const messageId = 'paddedTestBlocks';
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-class-names.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/sort-class-names');
 
 const parserOptions = {
@@ -17,7 +16,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const message = 'classes in className attribute must be sorted';
 

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/sort-import-destructures');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('sort-import-destructures', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/sort-imports.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/sort-imports');
 
 const parserOptions = {
@@ -14,7 +13,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 ruleTester.run('sort-imports', rule, {
 	invalid: [

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/trim-class-names.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/trim-class-names.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {RuleTester} = require('eslint');
-
+const MultiTester = require('../../../../../scripts/MultiTester');
 const rule = require('../../../lib/rules/trim-class-names');
 
 const parserOptions = {
@@ -17,7 +16,7 @@ const parserOptions = {
 	},
 };
 
-const ruleTester = new RuleTester(parserOptions);
+const ruleTester = new MultiTester(parserOptions);
 
 const message = 'classes in className attribute must be trimmed';
 

--- a/scripts/MultiTester.js
+++ b/scripts/MultiTester.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+const {RuleTester} = require('eslint');
+
+/**
+ * Wrapper for ESLint's RuleTester class that runs tests against both the
+ * standard ("espree") parser and the `@typescript-eslint/parser` one.
+ */
+class MultiTester extends RuleTester {
+	constructor(options) {
+		super(options);
+
+		this._liferay = {
+			parsers: {
+				espree: new RuleTester(options),
+				typescript: new RuleTester({
+					...options,
+					parser: require.resolve('@typescript-eslint/parser'),
+				}),
+			},
+		};
+	}
+
+	run(name, rule, tests) {
+		Object.entries(this._liferay.parsers).forEach(([key, parser]) => {
+			parser.run(`${name} (parser: ${key})`, rule, tests);
+		});
+	}
+}
+
+module.exports = MultiTester;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
   integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
@@ -30,7 +30,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.6.0", "@babel/generator@^7.8.3":
+"@babel/generator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
   integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
@@ -40,7 +40,7 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.1.0", "@babel/helper-function-name@^7.8.3":
+"@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
   integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
@@ -49,7 +49,7 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-get-function-arity@^7.0.0", "@babel/helper-get-function-arity@^7.8.3":
+"@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
   integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
@@ -61,14 +61,14 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
 
-"@babel/helper-split-export-declaration@^7.4.4", "@babel/helper-split-export-declaration@^7.8.3":
+"@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helpers@^7.6.0", "@babel/helpers@^7.8.3":
+"@babel/helpers@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.3.tgz#382fbb0382ce7c4ce905945ab9641d688336ce85"
   integrity sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
@@ -77,7 +77,7 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/highlight@^7.0.0", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
   integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
@@ -86,7 +86,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.6.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.3":
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
@@ -105,7 +105,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/template@^7.1.0", "@babel/template@^7.6.0", "@babel/template@^7.7.4", "@babel/template@^7.8.3":
+"@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
   integrity sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
@@ -114,7 +114,7 @@
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.6.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
   integrity sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
@@ -129,7 +129,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.8.3":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
@@ -370,6 +370,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -390,6 +395,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -406,6 +416,38 @@
   integrity sha512-hFkuAp58M2xOc1QgJhkFrLMnqa8KWTFRTnzrI1zlEcOfg3DZ0eH3aPAo/N6QlVVu8E4KS4xD1jtEG3rdQYFmIg==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/experimental-utils@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.20.0.tgz#3b6fa5a6b8885f126d5a4280e0d44f0f41e73e32"
+  integrity sha512-fEBy9xYrwG9hfBLFEwGW2lKwDRTmYzH3DwTmYbT+SMycmxAoPl0eGretnBFj/s+NfYBG63w/5c3lsvqqz5mYag==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.20.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.20.0.tgz#608e5bb06ba98a415b64ace994c79ab20f9772a9"
+  integrity sha512-o8qsKaosLh2qhMZiHNtaHKTHyCHc3Triq6aMnwnWj7budm3xAY9owSZzV1uon5T9cWmJRJGzTFa90aex4m77Lw==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.20.0"
+    "@typescript-eslint/typescript-estree" "2.20.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz#90a0f5598826b35b966ca83483b1a621b1a4d0c9"
+  integrity sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 abab@^2.0.0:
   version "2.0.1"
@@ -855,7 +897,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -1532,7 +1574,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3647,15 +3689,22 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+tslib@^1.8.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
+  integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
 
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3697,6 +3746,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,15 +3689,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
   integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
-
-tslib@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
The sort-import-destructures rule was working fine in liferay-portal and in our local test suite, but I discovered while updating the version of eslint-config-liferay used in Clay to v19.0.1 that the rule's autofixer was mangling the source because the `start` and `end` properties are undefined when using the `@typescript-eslint/parser` parser.

`range[0]` and `range[1]`, however, are equivalent, and are set by both `@typescript-eslint/parser` and the standard (espree) parser.

Test plan: In addition to manual fixing, adjusted the tests to always run against both espree and `@typescript-eslint/parser`. Sample failure output looks like this (note the "parser:" annotation):

    FAIL  plugins/eslint-plugin-liferay/tests/lib/rules/sort-import-destructures.js
      ● sort-import-destructures (parser: typescript) › invalid › example 1: import {z, g} from 'a';

        assert(received)

        Expected value to be equal to:
          true
        Received:
          false