### PR TITLE
chore: Add licensing header to the remainder of files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
+# © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 /.eslintrc-internal.js
 /copyright.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-# © 2020 Liferay Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 ---
 # Configuration for the Semantic Pull Request bot.
 # https://github.com/probot/semantic-pull-requests

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 /.eslintrc-internal.js
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-# © 2020 Liferay Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
+# © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Generated file.
 /.eslintrc-internal.js
 

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,0 +1,3 @@
+© 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,3 +1,3 @@
-© 2020 Liferay Inc. <https://liferay.com>
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 
 SPDX-License-Identifier: MIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 install:
   - yarn
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,7 @@
+# © 2020 Liferay Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "v"
 version-git-message "chore: prepare v%s release"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
-# © 2020 Liferay Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
-
-SPDX-License-Identifier: MIT
--->
-
 ## [v19.0.1](https://github.com/liferay/eslint-config-liferay/tree/v19.0.1) (2020-02-10)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v19.0.0...v19.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 ## [v19.0.1](https://github.com/liferay/eslint-config-liferay/tree/v19.0.1) (2020-02-10)
 
 [Full changelog](https://github.com/liferay/eslint-config-liferay/compare/v19.0.0...v19.0.1)

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Release process
 
 1.  Confirm that you have a clean worktree.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # eslint-config-liferay
 
 > An ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) that helps enforce the [Liferay Frontend Guidelines](https://github.com/liferay/liferay-frontend-guidelines).

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+© 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-© 2020 Liferay Inc. <https://liferay.com>
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 
 SPDX-License-Identifier: MIT

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow unnecessary extensions in configuration files (no-explicit-extends)
 
 This rule guards against unnecessary extensions in configuration files.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-global-fetch.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-global-fetch.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow use of global fetch (no-global-fetch)
 
 This rule guards against the direct use of the `fetch` API. As a secured-environment, Liferay Portal requests often rely on specific security headers and tokens being set in the requests. The `frontend-js-web` module offers a thin wrapper around `fetch` that takes care of the most common configuration to avoid issues.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-loader-import-specifier.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-loader-import-specifier.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow use of specifiers for non-JS resources imported via the loader (no-loader-import-specifier)
 
 The Liferay bundler [provides various loaders](https://github.com/liferay/liferay-js-toolkit/wiki/List-of-loaders) for injecting non-JS resources (for example, CSS, SCSS) into a page. These resources should be included via `import` statements for their side effects only, and not bound to a name using an import specifier.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-metal-plugins.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow use of deprecated metal plugins (no-metal-plugins)
 
 This rule guards against the use of various deprecated metal plugins such as:

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-react-dom-render.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow direct use of `ReactDOM.render` (no-react-dom-render)
 
 This rule guards against the direct use of the `ReactDOM.render` API, in favor of our [custom `render` wrapper](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.es.js) implemented in `frontend-js-react-web`.

--- a/plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md
+++ b/plugins/eslint-plugin-liferay-portal/docs/rules/no-side-navigation.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Disallow use of deprecated jQuery `sideNavigation` plugin (no-side-navigation)
 
 This rule guards against the use of the deprecated jQuery `sideNavigation()` API, which was ported to vanilla JavaScript in [LPS-95476](https://github.com/brianchandotcom/liferay-portal/pull/74090).

--- a/plugins/eslint-plugin-liferay-portal/package.json.license
+++ b/plugins/eslint-plugin-liferay-portal/package.json.license
@@ -1,0 +1,3 @@
+© 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/plugins/eslint-plugin-liferay-portal/package.json.license
+++ b/plugins/eslint-plugin-liferay-portal/package.json.license
@@ -1,3 +1,3 @@
-© 2020 Liferay Inc. <https://liferay.com>
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 
 SPDX-License-Identifier: MIT

--- a/plugins/eslint-plugin-liferay/docs/rules/array-is-array.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/array-is-array.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Force usage of `Array.isArray()` (array-is-array)
 
 Because it is [surprisingly difficult to reliably determine whether something is an `Array` in JavaScript](http://web.mit.edu/jwalden/www/isArray.html), [`Array.isArray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) should be used instead.

--- a/plugins/eslint-plugin-liferay/docs/rules/destructure-requires.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/destructure-requires.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # `require` statements should use destructuring (destructure-requires)
 
 For uniformity, all `require` statements should take the form of variable declarations that make the `require()` call and directly bind the result to one or more values.

--- a/plugins/eslint-plugin-liferay/docs/rules/group-imports.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/group-imports.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Group `import` statements and `require` calls (group-imports)
 
 This rule enforces (and autofixes) that `import` statements and `require` calls &mdash; henceforth referred to as just "imports" &mdash; appear in the groups described in [our guidelines](https://github.com/liferay/liferay-frontend-guidelines/issues/60).

--- a/plugins/eslint-plugin-liferay/docs/rules/import-extensions.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/import-extensions.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Omit extensions consistently with `import` and `require` (import-extensions)
 
 This rule enforces that `import` statements and `require` calls &mdash; henceforth referred to as just "imports" &mdash; use (or omit) file extensions consistently.

--- a/plugins/eslint-plugin-liferay/docs/rules/imports-first.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/imports-first.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # `import` statements and `require` calls should be at the top (imports-first)
 
 This rule enforces that `import` statements and `require` calls &mdash; henceforth referred to as just "imports" &mdash; appear at the top of the file, before other statements.

--- a/plugins/eslint-plugin-liferay/docs/rules/no-absolute-import.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-absolute-import.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # `import` declarations should not use absolute paths (no-absolute-import)
 
 This rule prohibits using an absolute path with `import` or `require()`.

--- a/plugins/eslint-plugin-liferay/docs/rules/no-duplicate-class-names.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-duplicate-class-names.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Class names inside the "className" JSX attribute must be unique (no-duplicate-class-names)
 
 This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are unique.

--- a/plugins/eslint-plugin-liferay/docs/rules/no-duplicate-imports.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-duplicate-imports.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # No duplicate `import` statements (no-duplicate-imports)
 
 This rule enforces that there is at most one `import` statement for a given module in each file. There is no autofix because it is hoped that this is a relative infrequent mistake.

--- a/plugins/eslint-plugin-liferay/docs/rules/no-dynamic-require.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-dynamic-require.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Use only literal arguments in `require` calls (no-dynamic-require)
 
 This rule prohibits non-literal arguments to `require()`.

--- a/plugins/eslint-plugin-liferay/docs/rules/no-it-should.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-it-should.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # `it()` strings should not start with "should" (no-it-should)
 
 This rule enforces that `it()` descriptions start with a verb, not with "should".

--- a/plugins/eslint-plugin-liferay/docs/rules/no-require-and-call.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/no-require-and-call.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Top-level `require` values should not be immediately called (no-require-and-call)
 
 To keep `require` statements simple, this rule disallows immediately calling the function returned by a `require()`.

--- a/plugins/eslint-plugin-liferay/docs/rules/padded-test-blocks.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/padded-test-blocks.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Consecutive test blocks (eg. `it()` etc) should be separated by a blank line (padded-test-blocks)
 
 This rule enforces that `it()` calls and other test blocks are separated by a blank line.

--- a/plugins/eslint-plugin-liferay/docs/rules/sort-class-names.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/sort-class-names.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Sort class names inside the "className" JSX attribute (sort-class-names)
 
 This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are sorted.

--- a/plugins/eslint-plugin-liferay/docs/rules/sort-import-destructures.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/sort-import-destructures.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Sort destructured names in `import` statements (sort-import-destructures)
 
 This rule enforces (and autofixes) that destructured names in `import` statements are sorted.

--- a/plugins/eslint-plugin-liferay/docs/rules/sort-imports.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/sort-imports.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Sort `import` statements and `require` calls (sort-imports)
 
 This rule enforces (and autofixes) that `import` statements and `require` calls &mdash; henceforth referred to as just "imports" &mdash; appear in the order described in [our guidelines](https://github.com/liferay/liferay-frontend-guidelines/issues/60).

--- a/plugins/eslint-plugin-liferay/docs/rules/trim-class-names.md
+++ b/plugins/eslint-plugin-liferay/docs/rules/trim-class-names.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Trim whitespace inside the "className" JSX attribute (trim-class-names)
 
 This rule enforces (and autofixes) that the class names inside the "className" attribute of a JSX element are not preceded or followed by whitespace.

--- a/plugins/eslint-plugin-liferay/package.json.license
+++ b/plugins/eslint-plugin-liferay/package.json.license
@@ -1,0 +1,3 @@
+© 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/plugins/eslint-plugin-liferay/package.json.license
+++ b/plugins/eslint-plugin-liferay/package.json.license
@@ -1,3 +1,3 @@
-© 2020 Liferay Inc. <https://liferay.com>
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 
 SPDX-License-Identifier: MIT

--- a/yarn.lock.license
+++ b/yarn.lock.license
@@ -1,0 +1,3 @@
+© 2020 Liferay Inc. <https://liferay.com>
+
+SPDX-License-Identifier: MIT

--- a/yarn.lock.license
+++ b/yarn.lock.license
@@ -1,3 +1,3 @@
-© 2020 Liferay Inc. <https://liferay.com>
+SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>
 
 SPDX-License-Identifier: MIT


### PR DESCRIPTION
cd6056f added a lot of headers. This commit addresses the files that were forgotten.

For posterity's sake, the process that went into creating this PR:

- I ran `reuse lint` (https://github.com/fsfe/reuse-tool)
- Copied the list of files it spat out into an editor, and made a Python list out of them.
- Created the following script:

```python
import subprocess

files = [
".eslintignore",
".github/semantic.yml",
".gitignore",
[...], # You get the idea.
]

for file_ in files:
    subprocess.run(["reuse", "addheader", "--license", "MIT", "--copyright", "SPDX-FileCopyrightText: © 2020 Liferay Inc. <https://liferay.com>", "--exclude-year", file_])
```

- Ran the script; the script failed for some files:

    * .eslintignore
    * .prettierignore
    * .prettierrc.json
    * .yarnrc
    * package.json
    * plugins/eslint-plugin-liferay/package.json
    * plugins/eslint-plugin-liferay-portal/package.json
    * yarn.lock

- Manually edited those files.

- Verified with `reuse lint`.

- Voilà.