### PR TITLE
fix(no-explicit-extend): avoid whitespace damage

### DIFF
--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -84,7 +84,7 @@ function fix(nodesToRemove, context, fixer) {
 
 			if (nodesToRemove.has(item)) {
 				return text;
-			} else if (index === lastRemaining) {
+			} else if (atEnd) {
 				return text + itemText;
 			} else {
 				return text + itemText + trailingWhitespace;

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -84,8 +84,6 @@ function fix(nodesToRemove, context, fixer) {
 
 			if (nodesToRemove.has(item)) {
 				return text;
-			} else if (atEnd) {
-				return text + itemText;
 			} else {
 				return text + itemText + trailingWhitespace;
 			}

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -37,13 +37,7 @@ function fix(nodesToRemove, context, fixer) {
 
 	if (nodesToRemove instanceof Set) {
 		// Removing elements from an ArrayExpression.
-		let parent;
-
-		for (const node of nodesToRemove) {
-			parent = node.parent;
-
-			break;
-		}
+		const parent = [...nodesToRemove][0].parent;
 
 		items = parent.elements.slice();
 	} else {

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -25,21 +25,21 @@ const noExplicitPreset =
 	'`@babel/preset-env` and `@babel/preset-react` apply automatically and can be omitted';
 
 /**
- * Expects either:
+ * Expects `nodesToRemove` to be either:
  *
  * - a Set of literals to prune from an ArrayExpression; or:
  * - a Property to prune from an ObjectExpression.
  */
-function fix(elementsOrProperty, context, fixer) {
+function fix(nodesToRemove, context, fixer) {
 	const source = context.getSourceCode();
 
 	let items;
 
-	if (elementsOrProperty instanceof Set) {
+	if (nodesToRemove instanceof Set) {
 		// Removing elements from an ArrayExpression.
 		let parent;
 
-		for (const node of elementsOrProperty) {
+		for (const node of nodesToRemove) {
 			parent = node.parent;
 
 			break;
@@ -48,7 +48,7 @@ function fix(elementsOrProperty, context, fixer) {
 		items = parent.elements.slice();
 	} else {
 		// Removing property from an ObjectExpression.
-		const parent = elementsOrProperty.parent;
+		const parent = nodesToRemove.parent;
 
 		// Special case: when removing last property, kill all
 		// internal whitespace.
@@ -56,7 +56,7 @@ function fix(elementsOrProperty, context, fixer) {
 			return fixer.replaceText(parent, '{}');
 		}
 
-		elementsOrProperty = new Set([elementsOrProperty]);
+		nodesToRemove = new Set([nodesToRemove]);
 		items = parent.properties.slice();
 	}
 
@@ -65,7 +65,7 @@ function fix(elementsOrProperty, context, fixer) {
 	const end = items[lastIndex].range[1];
 
 	const lastVisible = items.reduce((last, item, index) => {
-		if (elementsOrProperty.has(item)) {
+		if (nodesToRemove.has(item)) {
 			return last;
 		} else {
 			return index;
@@ -89,7 +89,7 @@ function fix(elementsOrProperty, context, fixer) {
 			// When removing last item, we eat preceding
 			// whitespace. When removing other items we eat trailing
 			// whitespace.
-			if (elementsOrProperty.has(item)) {
+			if (nodesToRemove.has(item)) {
 				return text;
 			} else if (index + 1 >= lastVisible) {
 				return text + itemText;

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -82,12 +82,9 @@ function fix(nodesToRemove, context, fixer) {
 						.getText()
 						.slice(item.range[1], items[index + 1].range[0]);
 
-			// When removing last item, we eat preceding
-			// whitespace. When removing other items we eat trailing
-			// whitespace.
 			if (nodesToRemove.has(item)) {
 				return text;
-			} else if (index + 1 >= lastRemaining) {
+			} else if (index === lastRemaining) {
 				return text + itemText;
 			} else {
 				return text + itemText + trailingWhitespace;

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -58,7 +58,9 @@ function fix(nodesToRemove, context, fixer) {
 	const start = items[0].range[0];
 	const end = items[lastIndex].range[1];
 
-	const lastVisible = items.reduce((last, item, index) => {
+	// Record index of last `item` in `items` that will remain after we've
+	// deleted `nodesToRemove`.
+	const lastRemaining = items.reduce((last, item, index) => {
 		if (nodesToRemove.has(item)) {
 			return last;
 		} else {
@@ -71,7 +73,7 @@ function fix(nodesToRemove, context, fixer) {
 	return fixer.replaceTextRange(
 		[start, end],
 		items.slice().reduce((text, item, index) => {
-			const atEnd = index >= lastVisible;
+			const atEnd = index >= lastRemaining;
 			const itemText = source.getText(item);
 
 			const trailingWhitespace = atEnd
@@ -85,7 +87,7 @@ function fix(nodesToRemove, context, fixer) {
 			// whitespace.
 			if (nodesToRemove.has(item)) {
 				return text;
-			} else if (index + 1 >= lastVisible) {
+			} else if (index + 1 >= lastRemaining) {
 				return text + itemText;
 			} else {
 				return text + itemText + trailingWhitespace;

--- a/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/no-explicit-extend.js
@@ -74,7 +74,6 @@ function fix(nodesToRemove, context, fixer) {
 		[start, end],
 		items.slice().reduce((text, item, index) => {
 			const atEnd = index >= lastRemaining;
-			const itemText = source.getText(item);
 
 			const trailingWhitespace = atEnd
 				? ''
@@ -85,6 +84,8 @@ function fix(nodesToRemove, context, fixer) {
 			if (nodesToRemove.has(item)) {
 				return text;
 			} else {
+				const itemText = source.getText(item);
+
 				return text + itemText + trailingWhitespace;
 			}
 		}, '')

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/no-explicit-extend.js
@@ -362,6 +362,40 @@ ruleTester.run('no-explicit-extend', rule, {
 				};
 			`,
 		},
+		{
+			// Regression.
+			// See: https://github.com/liferay/liferay-portal-ee/pull/18545#issuecomment-600614052
+			code: `
+				module.exports = {
+					extends: ['liferay/react'],
+					globals: {
+						AlloyEditor: true,
+						process: true
+					},
+					rules: {
+						'react/no-string-refs': 'off'
+					}
+				};
+			`,
+			errors: [
+				{
+					messageId: 'noExplicitExtend',
+					type: 'Property',
+				},
+			],
+			filename,
+			output: `
+				module.exports = {
+					globals: {
+						AlloyEditor: true,
+						process: true
+					},
+					rules: {
+						'react/no-string-refs': 'off'
+					}
+				};
+			`,
+		},
 	],
 
 	valid: [


### PR DESCRIPTION
The logic we were using to detect when to preserve whitespace damage was off, and I don't think the comment was very illuminating, so I removed it.

Here's another shot at describing it:

Given some nodes (A, B, C, D) and separators ("sep"), where the last separator may be optional; eg

    A sep B sep C sep D sep?

Loop over all, and:

    for X in ABCD:
      are we deleting X?:
        drop X
      else:
        emit X
        is X last remaining node?:
          done (don't emit "sep")
        else:
          emit "sep"

This should do the right thing with collections that have final trailing
commas:

    [
      a,
      b,
      c,
    ]

and those without:

    [
      a,
      b,
      c
    ]

First three commits are refactoring because, looking at this with fresh eyes, the opportunity presented itself. Actual fix is in last commit (https://github.com/liferay/eslint-config-liferay/commit/9635b6f03b7abc0f20f4439a5106872991461f16 — unless I have to force push for some reason 😀 ).