### PR TITLE
fix(import-extensions): handle exports without sources

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/rules/import-extensions.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/import-extensions.js
@@ -77,6 +77,7 @@ module.exports = {
 			} else if (
 				(node.type === 'ExportNamedDeclaration' ||
 					node.type === 'ExportAllDeclaration') &&
+				node.source &&
 				(node.source.type === 'Literal' ||
 					node.source.type === 'TemplateLiteral')
 			) {

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/import-extensions.js
@@ -155,5 +155,17 @@ ruleTester.run('import-extensions', rule, {
 		{
 			code: `const billboard = not_a_require('billboard.js');`,
 		},
+		{
+			// Regression discovered here:
+			//
+			// https://github.com/liferay/liferay-npm-tools/pull/429#issuecomment-608451060
+			//
+			// Can't assume that all exports have a source.
+			code: `
+				const foo = 1;
+
+				export {foo};
+			`,
+		},
 	],
 });


### PR DESCRIPTION
Discovered during test run [here](https://github.com/liferay/liferay-npm-tools/pull/429).