### PR TITLE
feat!: enforce use of strict (===) equality

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const config = {
 	rules: {
 		curly: 'error',
 		'default-case': 'error',
+		eqeqeq: ['error', 'always', {null: 'ignore'}],
 		'liferay/array-is-array': 'error',
 		'liferay/destructure-requires': 'error',
 		'liferay/group-imports': 'error',


### PR DESCRIPTION
ESLint can enforce this for us with the built-in "eqeqeq" rule, which you might not know about if you'd search for "strict", "equality" or "equal" in the rules list.

Idea is to avoid coercion due to `==`/`!=` which can be a source of bugs, except in the case of `null`, where `x == null` is a convenient and idiomatic shorthand for `x === null || x === undefined` (you can still do an explicit `x === null` check if that's what you want).

Docs: https://eslint.org/docs/rules/eqeqeq

Closes: https://github.com/liferay/eslint-config-liferay/issues/158