### PR TITLE
style: apply autofixes

### DIFF
--- a/plugins/eslint-plugin-liferay-portal/lib/rules/deprecation.js
+++ b/plugins/eslint-plugin-liferay-portal/lib/rules/deprecation.js
@@ -75,6 +75,7 @@ function fix(line) {
 					.startsWith(versionName.toLowerCase())
 			) {
 				// Name doesn't match version number: bail.
+
 				return;
 			}
 		}
@@ -82,6 +83,7 @@ function fix(line) {
 
 	if (!expectedName) {
 		// Didn't find any known version number: bail.
+
 		return;
 	}
 
@@ -93,6 +95,7 @@ function fix(line) {
 				replacement = `, replaced by ${trailer.trim()}`;
 			} else {
 				// Empty trailer: bail.
+
 				return;
 			}
 			break;
@@ -101,6 +104,7 @@ function fix(line) {
 		case 'with no direct replacement':
 			if (trailer.trim()) {
 				// Unexpected trailer: bail.
+
 				return;
 			} else {
 				replacement = ', with no direct replacement';
@@ -110,6 +114,7 @@ function fix(line) {
 		case '':
 			if (trailer.trim()) {
 				// Unexpected trailer: bail.
+
 				return;
 			}
 			break;
@@ -202,6 +207,7 @@ module.exports = {
 								if (fixable) {
 									// Replace only the _inside_ of comment,
 									// which corresponds to `comment.value`.
+
 									const range = [
 										comment.range[0] + '/*'.length,
 										comment.range[1] - '*/'.length,

--- a/plugins/eslint-plugin-liferay-portal/tests/lib/rules/deprecation.js
+++ b/plugins/eslint-plugin-liferay-portal/tests/lib/rules/deprecation.js
@@ -56,6 +56,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Shorthand version: 7.2 should be 7.2.x.
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.2), replaced by XYZ
@@ -75,6 +76,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Missing comma.
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.2.x) replaced by XYZ
@@ -94,6 +96,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Missing "direct".
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.2.x), with no replacement
@@ -113,6 +116,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Missing parentheses.
+
 			code: `
 				/**
 				 * @deprecated As of Mueller 7.2.x, with no direct replacement
@@ -132,6 +136,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Bad capitalization.
+
 			code: `
 				/**
 				 * @deprecated as of MUELLER (7.2.x), With NO direct replacement
@@ -151,6 +156,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Wrong conjunction ("From" instead of "As of"):
+
 			code: `
 				/**
 				 * @deprecated From Mueller (7.2.x), with no direct replacement
@@ -170,6 +176,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Wrong conjunction ("Since" instead of "As of"):
+
 			code: `
 				/**
 				 * @deprecated Since Mueller (7.2.x), with no direct replacement
@@ -189,6 +196,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Bad whitespace.
+
 			code: `
 				/**
 				 *@deprecated As of Mueller(7.2.x),with no direct replacement
@@ -208,6 +216,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Various things wrong at once.
+
 			code: `
 				/**
 				 *@deprecated As OF JUDSON 7.1 Replaced by Liferay.Bar
@@ -227,6 +236,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Invalid because of unwanted trailer.
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.2.x), with no direct replacement AFAIK
@@ -241,6 +251,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Invalid because of missing trailer.
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.2.x), replaced by
@@ -255,6 +266,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Invalid because of non-standard conjunction:
+
 			code: `
 				/**
 				 * @deprecated Around Mueller (7.2.x), replaced by Liferay.Foo
@@ -269,6 +281,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Invalid because name and version mismatch:
+
 			code: `
 				/**
 				 * @deprecated As of Mueller (7.0), replaced by XYZ
@@ -283,6 +296,7 @@ ruleTester.run('deprecation', rule, {
 		},
 		{
 			// Invalid because it is not multiline:
+
 			code: `
 				/* @deprecated As of Mueller (7.2.x), replaced by XYZ */
 			`,


### PR DESCRIPTION
Because these files are new since [#170](https://github.com/liferay/eslint-config-liferay/pull/170) was prepared. They need a `yarn lint:fix` to correct these issues:

    plugins/eslint-plugin-liferay-portal/lib/rules/deprecation.js
       77:5   error  Expected line after comment  lines-around-comment
       84:3   error  Expected line after comment  lines-around-comment
       95:5   error  Expected line after comment  lines-around-comment
      103:5   error  Expected line after comment  lines-around-comment
      112:5   error  Expected line after comment  lines-around-comment
      204:10  error  Expected line after comment  lines-around-comment

    plugins/eslint-plugin-liferay-portal/tests/lib/rules/deprecation.js
       58:4  error  Expected line after comment  lines-around-comment
       77:4  error  Expected line after comment  lines-around-comment
       96:4  error  Expected line after comment  lines-around-comment
      115:4  error  Expected line after comment  lines-around-comment
      134:4  error  Expected line after comment  lines-around-comment
      153:4  error  Expected line after comment  lines-around-comment
      172:4  error  Expected line after comment  lines-around-comment
      191:4  error  Expected line after comment  lines-around-comment
      210:4  error  Expected line after comment  lines-around-comment
      229:4  error  Expected line after comment  lines-around-comment
      243:4  error  Expected line after comment  lines-around-comment
      257:4  error  Expected line after comment  lines-around-comment
      271:4  error  Expected line after comment  lines-around-comment
      285:4  error  Expected line after comment  lines-around-comment

    ✖ 20 problems (20 errors, 0 warnings)
      20 errors and 0 warnings potentially fixable with the `--fix` option.