### PR TITLE
fix(group-imports): don't crash on multiple require calls in a statement

### DIFF
--- a/plugins/eslint-plugin-liferay/lib/rules/group-imports.js
+++ b/plugins/eslint-plugin-liferay/lib/rules/group-imports.js
@@ -124,13 +124,33 @@ module.exports = {
 
 					const current = imports[i];
 
+					const previous = imports[i - 1];
+
+					if (current === previous) {
+						// Can happen when a `require` is one of several
+						// VariableDeclarators in a VariableDeclaration; eg.
+						//
+						//      const a = require('a'), require('b');
+						//      ^         ^             ^
+						//      |          \             \
+						//      |           ---------------- VariableDeclators
+						//      current
+						//      (VariableDeclaration)
+						//
+						// ie. the `current` import statement ends up being the
+						// same for both `require` calls. We use the separate
+						// one-require-per-statement rule to break up these.
+
+						continue;
+					}
+
 					if (hasSideEffects(current)) {
 						expectBlankLines(current);
 						continue;
 					}
 
-					const previous = imports[i - 1];
 					const token = context.getTokenBefore(current);
+
 					const last = context.getNodeByRangeIndex(token.range[0]);
 
 					if (last !== previous) {

--- a/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
+++ b/plugins/eslint-plugin-liferay/tests/lib/rules/group-imports.js
@@ -125,5 +125,21 @@ ruleTester.run('group-imports', rule, {
 				const PluginError = require('plugin-error');
 			`,
 		},
+		{
+			// Regression test: input like this would cause:
+			//
+			//      TypeError: Cannot read property 'range' of null
+			//
+
+			code: `
+				const merge = require('webpack-merge'),
+					webpackBase = require('./webpack.config.js');
+			`,
+			errors: [],
+			output: `
+				const merge = require('webpack-merge'),
+					webpackBase = require('./webpack.config.js');
+			`,
+		},
 	],
 });


### PR DESCRIPTION
While dealing with an (unrelated) support request about linting on the 7.2.x branch, I ran a full-repo scan to see what the current issues where and noticed we were crashing on [this file](https://github.com/liferay/liferay-portal-ee/blob/476b035983c0ad5f9b6b5970ad7d3be4005971b7/modules/apps/commerce/commerce-frontend-js/.eslintrc.js) which contains this construct:

```js
const merge = require('webpack-merge'),
    webpackBase = require('./webpack.config.js');
```

As the comment in this commit explains, this leads us to blow up with:

    TypeError: Cannot read property 'range' of null

because when we try to get the token before the second `require` we get `null`, and that's because the `current` require statement is the entire `VariableDeclaration` (starting at `const merge`) and there is nothing before it.

So, in this commit, we handle this gracefully. We'll leave it to another rule to handle enforcement of one-require-per-statement. Ideally we'd be able to use of the built-in ESLint rules for this, but the closest candidates are for a different purpose, so I've mentioned a not-yet-written-rule that we can implement subsequently:

-   https://eslint.org/docs/rules/one-var
-   https://eslint.org/docs/rules/one-var-declaration-per-line